### PR TITLE
Fix deanonymization path sanitization

### DIFF
--- a/anonyfiles_api/routers/deanonymization.py
+++ b/anonyfiles_api/routers/deanonymization.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, UploadFile, File, Form, BackgroundTasks, HTTPExce
 from fastapi.responses import JSONResponse
 from fastapi.concurrency import run_in_threadpool
 from pathlib import Path
+import aiofiles
 import uuid
 import json
 import sys
@@ -150,9 +151,9 @@ async def deanonymize_file_endpoint(
 
     await run_in_threadpool(job_dir.mkdir, parents=True, exist_ok=True)
 
-    input_filename = file.filename if file.filename else "input_file_to_deanonymize"
-    mapping_filename = mapping.filename if mapping.filename else "mapping_file.csv"
-    
+    input_filename = Path(file.filename).name if file.filename else "input_file_to_deanonymize"
+    mapping_filename = Path(mapping.filename).name if mapping.filename else "mapping_file.csv"
+
     input_path = job_dir / input_filename
     mapping_path = job_dir / mapping_filename
 

--- a/tests/api/test_deanonymization_path_safety.py
+++ b/tests/api/test_deanonymization_path_safety.py
@@ -1,0 +1,48 @@
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import importlib
+
+import anonyfiles_api.core_config as core_config
+
+
+def test_deanonymize_sanitizes_filenames(tmp_path):
+    # Redirect JOBS_DIR to a temporary location
+    original_jobs_dir = core_config.JOBS_DIR
+    core_config.JOBS_DIR = tmp_path
+    try:
+        saved = {}
+        # Import the API after mocking heavy dependencies like spaCy
+        import sys
+        sys.modules.setdefault("spacy", importlib.util.module_from_spec(importlib.machinery.ModuleSpec("spacy", None)))
+        from anonyfiles_api.api import app
+        def fake_run_deanonymization_job_sync(job_id, input_path, mapping_path, permissive):
+            saved['job_id'] = job_id
+            saved['input_path'] = input_path
+            saved['mapping_path'] = mapping_path
+
+        with patch(
+            "anonyfiles_api.routers.deanonymization.run_deanonymization_job_sync",
+            side_effect=fake_run_deanonymization_job_sync,
+        ):
+            client = TestClient(app)
+            files = {
+                "file": ("../secret.txt", b"data"),
+                "mapping": ("../../map.csv", b"code,original\nA,B"),
+            }
+            resp = client.post("/deanonymize/", files=files, data={"permissive": "false"})
+            assert resp.status_code == 200
+
+        job_id = saved['job_id']
+        job_dir = tmp_path / job_id
+        assert (job_dir / "secret.txt").is_file()
+        assert (job_dir / "map.csv").is_file()
+        assert saved['input_path'] == job_dir / "secret.txt"
+        assert saved['mapping_path'] == job_dir / "map.csv"
+    finally:
+        core_config.JOBS_DIR = original_jobs_dir
+        shutil.rmtree(tmp_path / saved.get('job_id', ''), ignore_errors=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is in sys.path for test imports
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- sanitize filenames in deanonymization endpoint
- use sanitized names for saved paths
- add tests to ensure path traversal is prevented
- add test configuration helper

## Testing
- `pytest -q tests/api/test_deanonymization_path_safety.py`

------
https://chatgpt.com/codex/tasks/task_e_6842231b5a588323afa79a339e8ecb45