### PR TITLE
Implement reconstruct_and_write support

### DIFF
--- a/anonyfiles_cli/anonymizer/excel_processor.py
+++ b/anonyfiles_cli/anonymizer/excel_processor.py
@@ -64,3 +64,31 @@ class ExcelProcessor(BaseProcessor):
             os.makedirs(output_dir, exist_ok=True)
 
         anonymized_df.to_excel(output_path, index=False)
+
+    def reconstruct_and_write_anonymized_file(
+        self,
+        output_path,
+        final_processed_blocks,
+        original_input_path,
+        **kwargs
+    ):
+        """Reconstruit un fichier Excel à partir des blocs traités et l'enregistre."""
+        df = pd.read_excel(original_input_path)
+
+        if df.empty:
+            df.to_excel(output_path, index=False)
+            return
+
+        anonymized_df = df.copy()
+        cell_index_counter = 0
+        for row_index in range(anonymized_df.shape[0]):
+            for col_index in range(anonymized_df.shape[1]):
+                if cell_index_counter < len(final_processed_blocks):
+                    anonymized_df.iloc[row_index, col_index] = final_processed_blocks[cell_index_counter]
+                cell_index_counter += 1
+
+        output_dir = os.path.dirname(output_path)
+        if output_dir and not os.path.exists(output_dir):
+            os.makedirs(output_dir, exist_ok=True)
+
+        anonymized_df.to_excel(output_path, index=False)

--- a/anonyfiles_cli/anonymizer/pdf_processor.py
+++ b/anonyfiles_cli/anonymizer/pdf_processor.py
@@ -42,3 +42,37 @@ class PdfProcessor(BaseProcessor):
         if output_dir and not os.path.exists(output_dir):
             os.makedirs(output_dir, exist_ok=True)
         doc.save(output_path)
+
+    def reconstruct_and_write_anonymized_file(
+        self,
+        output_path,
+        final_processed_blocks,
+        original_input_path,
+        entities_per_block_with_offsets=None,
+        **kwargs
+    ):
+        """Reconstruit un PDF en appliquant les redactions basées sur les entités."""
+        doc = fitz.open(original_input_path)
+
+        if entities_per_block_with_offsets is None:
+            entities_per_block_with_offsets = kwargs.get("entities_per_block_with_offsets", [])
+
+        for page_num, page in enumerate(doc):
+            if page_num >= len(entities_per_block_with_offsets):
+                break
+            entities = entities_per_block_with_offsets[page_num]
+            if not entities:
+                continue
+
+            for ent_text, ent_label, start, end in entities:
+                areas = page.search_for(ent_text)
+                for area in areas:
+                    page.add_redact_annot(area, fill=(1, 1, 1))
+
+            page.apply_redactions()
+
+        output_dir = os.path.dirname(output_path)
+        if output_dir and not os.path.exists(output_dir):
+            os.makedirs(output_dir, exist_ok=True)
+
+        doc.save(output_path)

--- a/anonyfiles_cli/anonymizer/word_processor.py
+++ b/anonyfiles_cli/anonymizer/word_processor.py
@@ -67,3 +67,31 @@ class DocxProcessor(BaseProcessor):
             os.makedirs(output_dir, exist_ok=True)
 
         doc.save(output_path)
+
+    def reconstruct_and_write_anonymized_file(
+        self,
+        output_path,
+        final_processed_blocks,
+        original_input_path,
+        **kwargs
+    ):
+        """Reconstruit un document DOCX à partir des blocs traités et l'enregistre."""
+        doc = Document(original_input_path)
+        paragraphs = doc.paragraphs
+
+        for i, p in enumerate(paragraphs):
+            new_text = ""
+            if i < len(final_processed_blocks):
+                new_text = final_processed_blocks[i]
+
+            for run_element in p._element.xpath('./w:r'):
+                run_element.getparent().remove(run_element)
+
+            if new_text.strip():
+                p.add_run(new_text)
+
+        output_dir = os.path.dirname(output_path)
+        if output_dir and not os.path.exists(output_dir):
+            os.makedirs(output_dir, exist_ok=True)
+
+        doc.save(output_path)

--- a/tests/cli/test_docx_processor.py
+++ b/tests/cli/test_docx_processor.py
@@ -1,6 +1,6 @@
-import pytest; pytest.skip("processor API changed", allow_module_level=True)
 from anonyfiles_cli.anonymizer.word_processor import DocxProcessor
 from docx import Document
+from pathlib import Path
 import tempfile, os
 
 def test_extract_blocks_docx():
@@ -14,16 +14,23 @@ def test_extract_blocks_docx():
     assert len(blocks) == 2
     assert "Pierre" in blocks[0]
 
-def test_replace_entities_docx():
+def test_reconstruct_and_write_anonymized_file_docx():
     tmp_in = tempfile.NamedTemporaryFile("w+b", delete=False, suffix=".docx")
     tmp_out = tempfile.NamedTemporaryFile("w+b", delete=False, suffix=".docx")
     doc = Document()
     doc.add_paragraph("Pierre à Paris.")
     doc.save(tmp_in.name)
     processor = DocxProcessor()
-    replacements = {"Pierre": "NOM003", "Paris": "VILLE_Z"}
-    entities_offsets = [[("Pierre", "PER", 0, 6), ("Paris", "LOC", 9, 14)]]
-    processor.replace_entities(tmp_in.name, tmp_out.name, replacements, entities_offsets)
+
+    blocks = processor.extract_blocks(tmp_in.name)
+    final_blocks = [b.replace("Pierre", "NOM003").replace("Paris", "VILLE_Z") for b in blocks]
+
+    processor.reconstruct_and_write_anonymized_file(
+        Path(tmp_out.name),
+        final_blocks,
+        Path(tmp_in.name),
+    )
+
     doc_result = Document(tmp_out.name)
     assert "NOM003" in doc_result.paragraphs[0].text
     assert "VILLE_Z" in doc_result.paragraphs[0].text

--- a/tests/cli/test_excel_processor.py
+++ b/tests/cli/test_excel_processor.py
@@ -1,7 +1,7 @@
-import pytest; pytest.skip("processor API changed", allow_module_level=True)
 import tempfile
 import pandas as pd
 from anonyfiles_cli.anonymizer.excel_processor import ExcelProcessor
+from pathlib import Path
 
 def test_extract_blocks_excel():
     tmp = tempfile.NamedTemporaryFile("w+b", delete=False, suffix=".xlsx")
@@ -11,15 +11,15 @@ def test_extract_blocks_excel():
     blocks = processor.extract_blocks(tmp.name)
     assert "Alice" in blocks and "Paris" in blocks
 
-def test_replace_entities_excel():
+def test_reconstruct_and_write_anonymized_file_excel():
     tmp_in = tempfile.NamedTemporaryFile("w+b", delete=False, suffix=".xlsx")
     tmp_out = tempfile.NamedTemporaryFile("w+b", delete=False, suffix=".xlsx")
     df = pd.DataFrame({"A": ["Alice"], "B": ["Paris"]})
     df.to_excel(tmp_in.name, index=False)
     processor = ExcelProcessor()
-    replacements = {"Alice": "NOM004", "Paris": "VILLE_W"}
-    entities_offsets = [[("Alice", "PER", 0, 5)], [("Paris", "LOC", 0, 5)]]
-    processor.replace_entities(tmp_in.name, tmp_out.name, replacements, entities_offsets)
+    blocks = processor.extract_blocks(tmp_in.name)
+    final_blocks = [b.replace("Alice", "NOM004").replace("Paris", "VILLE_W") for b in blocks]
+    processor.reconstruct_and_write_anonymized_file(Path(tmp_out.name), final_blocks, Path(tmp_in.name))
     result = pd.read_excel(tmp_out.name)
     assert "NOM004" in result.values
     assert "VILLE_W" in result.values


### PR DESCRIPTION
## Summary
- add `reconstruct_and_write_anonymized_file` implementations for DOCX, Excel and PDF processors
- switch CLI processor tests to use the new reconstruction API
- remove obsolete skips in processor tests

## Testing
- `pytest -q tests/cli/test_docx_processor.py tests/cli/test_txt_processor.py tests/cli/test_json_processor.py tests/cli/test_excel_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_6842c1c9ff9c8323badd605896b5be9d