### PR TITLE
Update pdf reconstruction

### DIFF
--- a/anonyfiles_cli/anonymizer/csv_processor.py
+++ b/anonyfiles_cli/anonymizer/csv_processor.py
@@ -20,7 +20,7 @@ class CsvProcessor(BaseProcessor):
         Retourne une liste à plat contenant toutes les cellules de données (pas de header si has_header=True).
         L'option 'has_header' est récupérée via kwargs.
         """
-        has_header = kwargs.get('has_header', True)
+        has_header = kwargs.get('has_header', False)
         cell_texts: List[str] = []
         try:
             with open(input_path, mode='r', encoding='utf-8', newline='') as f:
@@ -48,7 +48,7 @@ class CsvProcessor(BaseProcessor):
         Reconstruit le fichier CSV en utilisant les blocs de texte (cellules) finalisés
         et l'écrit dans output_path.
         """
-        has_header = kwargs.get('has_header', True)
+        has_header = kwargs.get('has_header', False)
         anonymized_rows: List[List[str]] = []
         original_row_structures: List[int] = []
         header_row: List[str] = []

--- a/tests/cli/test_pdf_processor.py
+++ b/tests/cli/test_pdf_processor.py
@@ -1,0 +1,32 @@
+import tempfile
+from pathlib import Path
+import fitz
+
+from anonyfiles_cli.anonymizer.pdf_processor import PdfProcessor
+
+
+def create_simple_pdf(path: Path, text: str) -> None:
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), text)
+    doc.save(path)
+
+
+def test_reconstruct_and_write_anonymized_file_pdf():
+    tmp_in = tempfile.NamedTemporaryFile(delete=False, suffix=".pdf")
+    tmp_out = tempfile.NamedTemporaryFile(delete=False, suffix=".pdf")
+
+    create_simple_pdf(Path(tmp_in.name), "Pierre habite a Paris")
+
+    processor = PdfProcessor()
+    blocks = processor.extract_blocks(tmp_in.name)
+    final_blocks = [b.replace("Pierre", "NOM001").replace("Paris", "VILLE_X") for b in blocks]
+
+    processor.reconstruct_and_write_anonymized_file(
+        Path(tmp_out.name), final_blocks, Path(tmp_in.name)
+    )
+
+    res_doc = fitz.open(tmp_out.name)
+    page_text = res_doc[0].get_text("text").strip()
+    assert "NOM001" in page_text
+    assert "VILLE_X" in page_text


### PR DESCRIPTION
## Summary
- rebuild PDF pages from processed blocks and optionally apply redactions
- adjust CSV processor defaults to handle files without headers by default
- test PDF processor reconstruction behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c7a2891c83238e169e9463a83967