### PR TITLE
Add length mismatches checks for Docx/Excel processors

### DIFF
--- a/anonyfiles_cli/anonymizer/excel_processor.py
+++ b/anonyfiles_cli/anonymizer/excel_processor.py
@@ -2,8 +2,11 @@
 
 import pandas as pd
 import os
+import logging
 from .base_processor import BaseProcessor
 from .utils import apply_positional_replacements
+
+logger = logging.getLogger(__name__)
 
 class ExcelProcessor(BaseProcessor):
     """
@@ -78,6 +81,18 @@ class ExcelProcessor(BaseProcessor):
         if df.empty:
             df.to_excel(output_path, index=False)
             return
+
+        expected_count = int(df.shape[0] * df.shape[1])
+        if expected_count != len(final_processed_blocks):
+            logger.warning(
+                "Mismatch entre %s cellules attendues et %s blocs fournis pour %s",
+                expected_count,
+                len(final_processed_blocks),
+                output_path,
+            )
+            raise ValueError(
+                f"Le nombre de cellules ({expected_count}) ne correspond pas au nombre de blocs finaux ({len(final_processed_blocks)})."
+            )
 
         anonymized_df = df.copy()
         cell_index_counter = 0

--- a/anonyfiles_cli/anonymizer/word_processor.py
+++ b/anonyfiles_cli/anonymizer/word_processor.py
@@ -1,9 +1,12 @@
 # anonymizer/word_processor.py
 
 import os
+import logging
 from docx import Document
 from .base_processor import BaseProcessor
 from .utils import apply_positional_replacements
+
+logger = logging.getLogger(__name__)
 
 class DocxProcessor(BaseProcessor):
     """
@@ -78,6 +81,18 @@ class DocxProcessor(BaseProcessor):
         """Reconstruit un document DOCX à partir des blocs traités et l'enregistre."""
         doc = Document(original_input_path)
         paragraphs = doc.paragraphs
+
+        expected_count = len(paragraphs)
+        if expected_count != len(final_processed_blocks):
+            logger.warning(
+                "Mismatch entre %s paragraphes attendus et %s blocs fournis pour %s",
+                expected_count,
+                len(final_processed_blocks),
+                output_path,
+            )
+            raise ValueError(
+                f"Le nombre de paragraphes ({expected_count}) ne correspond pas au nombre de blocs finaux ({len(final_processed_blocks)})."
+            )
 
         for i, p in enumerate(paragraphs):
             new_text = ""

--- a/tests/cli/test_docx_processor.py
+++ b/tests/cli/test_docx_processor.py
@@ -2,6 +2,7 @@ from anonyfiles_cli.anonymizer.word_processor import DocxProcessor
 from docx import Document
 from pathlib import Path
 import tempfile, os
+import pytest
 
 def test_extract_blocks_docx():
     tmp = tempfile.NamedTemporaryFile("w+b", delete=False, suffix=".docx")
@@ -34,3 +35,21 @@ def test_reconstruct_and_write_anonymized_file_docx():
     doc_result = Document(tmp_out.name)
     assert "NOM003" in doc_result.paragraphs[0].text
     assert "VILLE_Z" in doc_result.paragraphs[0].text
+
+
+def test_reconstruct_and_write_anonymized_file_docx_mismatch():
+    tmp_in = tempfile.NamedTemporaryFile("w+b", delete=False, suffix=".docx")
+    tmp_out = tempfile.NamedTemporaryFile("w+b", delete=False, suffix=".docx")
+    doc = Document()
+    doc.add_paragraph("Texte unique")
+    doc.save(tmp_in.name)
+
+    processor = DocxProcessor()
+
+    # Fournir une liste vide pour provoquer un décalage de compte
+    with pytest.raises(ValueError):
+        processor.reconstruct_and_write_anonymized_file(
+            Path(tmp_out.name),
+            [],
+            Path(tmp_in.name),
+        )

--- a/tests/cli/test_excel_processor.py
+++ b/tests/cli/test_excel_processor.py
@@ -2,6 +2,7 @@ import tempfile
 import pandas as pd
 from anonyfiles_cli.anonymizer.excel_processor import ExcelProcessor
 from pathlib import Path
+import pytest
 
 def test_extract_blocks_excel():
     tmp = tempfile.NamedTemporaryFile("w+b", delete=False, suffix=".xlsx")
@@ -23,3 +24,19 @@ def test_reconstruct_and_write_anonymized_file_excel():
     result = pd.read_excel(tmp_out.name)
     assert "NOM004" in result.values
     assert "VILLE_W" in result.values
+
+
+def test_reconstruct_and_write_anonymized_file_excel_mismatch():
+    tmp_in = tempfile.NamedTemporaryFile("w+b", delete=False, suffix=".xlsx")
+    tmp_out = tempfile.NamedTemporaryFile("w+b", delete=False, suffix=".xlsx")
+    df = pd.DataFrame({"A": ["Alice"], "B": ["Paris"]})
+    df.to_excel(tmp_in.name, index=False)
+    processor = ExcelProcessor()
+
+    # Liste de blocs vide pour déclencher l'erreur
+    with pytest.raises(ValueError):
+        processor.reconstruct_and_write_anonymized_file(
+            Path(tmp_out.name),
+            [],
+            Path(tmp_in.name),
+        )


### PR DESCRIPTION
## Summary
- warn and raise `ValueError` in `DocxProcessor.reconstruct_and_write_anonymized_file` when block count mismatches
- warn and raise `ValueError` in `ExcelProcessor.reconstruct_and_write_anonymized_file` when block count mismatches
- test new mismatch behaviour for both processors

## Testing
- `pytest tests/cli/test_docx_processor.py tests/cli/test_excel_processor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6842cc4e0dd88323883e258d44ec89da