### PR TITLE
Improve JSON processor anonymization logic

### DIFF
--- a/anonyfiles_cli/anonymizer/json_processor.py
+++ b/anonyfiles_cli/anonymizer/json_processor.py
@@ -1,65 +1,128 @@
 # anonyfiles_cli/anonymizer/json_processor.py
 
 import json
-import os
 import logging
 from pathlib import Path
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Tuple
 
 from .base_processor import BaseProcessor
 # from .utils import apply_positional_replacements # Probablement plus nécessaire ici
 
 logger = logging.getLogger(__name__)
 
+
 class JsonProcessor(BaseProcessor):
-    def extract_blocks(self, input_path: Path, **kwargs) -> List[str]:
+    def __init__(self) -> None:
+        self._original_json: Any = None
+        self._value_paths: List[List[Any]] = []
+        self._key_paths: List[Tuple[List[Any], str]] = []
+
+    def _traverse(
+        self,
+        node: Any,
+        path: List[Any],
+        collect_all: bool,
+        values: List[str],
+        target_keys: Optional[set],
+        anonymize_keys: bool,
+    ) -> None:
+        """Recursively collect values and key names from the JSON tree."""
+        if isinstance(node, dict):
+            for k, v in node.items():
+                if anonymize_keys:
+                    # Track keys for anonymization
+                    self._key_paths.append((path, k))
+                    values.append(str(k))
+
+                next_collect = collect_all or (target_keys and k in target_keys)
+
+                if isinstance(v, (dict, list)):
+                    self._traverse(v, path + [k], next_collect, values, target_keys, anonymize_keys)
+                else:
+                    if next_collect or target_keys is None:
+                        self._value_paths.append(path + [k])
+                        values.append(str(v))
+        elif isinstance(node, list):
+            for idx, item in enumerate(node):
+                if isinstance(item, (dict, list)):
+                    self._traverse(item, path + [idx], collect_all, values, target_keys, anonymize_keys)
+                else:
+                    if collect_all or target_keys is None:
+                        self._value_paths.append(path + [idx])
+                        values.append(str(item))
+        else:
+            if collect_all or target_keys is None:
+                self._value_paths.append(path)
+                values.append(str(node))
+
+    def extract_blocks(
+        self,
+        input_path: Path,
+        *,
+        anonymize_keys: bool = False,
+        target_keys: Optional[List[str]] = None,
+        **kwargs,
+    ) -> List[str]:
         try:
             with open(input_path, "r", encoding="utf-8") as f:
-                return [f.read()]
+                self._original_json = json.load(f)
         except FileNotFoundError:
             raise
         except Exception as e:
             logger.error("Erreur lors de la lecture de %s: %s", input_path, e)
-            return [""]
+            self._original_json = None
+            return []
+
+        self._value_paths = []
+        self._key_paths = []
+        collected_values: List[str] = []
+        keys_set = set(target_keys) if target_keys else None
+        self._traverse(self._original_json, [], False, collected_values, keys_set, anonymize_keys)
+        return collected_values
 
 
     def reconstruct_and_write_anonymized_file(
         self,
         output_path: Path,
-        final_processed_blocks: List[str], # Devrait contenir un seul élément pour JSON
-        original_input_path: Path, # Non utilisé pour la reconstruction JSON simple
+        final_processed_blocks: List[str],
+        original_input_path: Path,
         **kwargs
     ) -> None:
-        content_to_write = ""
-        if final_processed_blocks:
-            content_to_write = final_processed_blocks[0]
-        else:
-            logger.info(
-                "INFO (JsonProcessor): Aucun bloc traité fourni pour %s, écriture d'un JSON vide (ou texte vide).",
-                output_path,
-            )
-            # Pour un JSON, un contenu vide pourrait être "{}", "[]", ou juste "" selon la sémantique désirée.
-            # Ici, on écrit ce que l'Engine a produit.
+        if self._original_json is None:
+            with open(original_input_path, "r", encoding="utf-8") as f:
+                self._original_json = json.load(f)
 
-        output_dir = output_path.parent
-        if not output_dir.exists():
-            output_dir.mkdir(parents=True, exist_ok=True)
+        anonymized_json = json.loads(json.dumps(self._original_json))
 
-        # Optionnel: Tenter de parser et réécrire en JSON formaté
-        # Cela échouera si les remplacements ont cassé la structure JSON.
-        try:
-            parsed_json = json.loads(content_to_write)
-            with open(output_path, 'w', encoding='utf-8') as fout:
-                json.dump(parsed_json, fout, indent=2, ensure_ascii=False)
-        except json.JSONDecodeError:
-            # Si ce n'est plus du JSON valide (par exemple, si des clés ont été anonymisées
-            # d'une manière qui casse la structure), on écrit le texte tel quel.
-            logger.warning(
-                "AVERTISSEMENT (JsonProcessor): Le contenu pour %s n'est plus un JSON valide après traitement. Écriture en tant que texte brut.",
-                output_path,
-            )
-            with open(output_path, 'w', encoding='utf-8') as fout:
-                fout.write(content_to_write)
+        def get_parent(obj: Any, path: List[Any]) -> Tuple[Any, Any]:
+            cur = obj
+            for p in path[:-1]:
+                cur = cur[p]
+            return cur, path[-1]
+
+        index = 0
+        # Replace values
+        for path in self._value_paths:
+            if index >= len(final_processed_blocks):
+                break
+            parent, key = get_parent(anonymized_json, path)
+            parent[key] = final_processed_blocks[index]
+            index += 1
+
+        # Replace keys
+        for parent_path, old_key in self._key_paths:
+            if index >= len(final_processed_blocks):
+                break
+            parent = anonymized_json
+            for p in parent_path:
+                parent = parent[p]
+            new_key = final_processed_blocks[index]
+            index += 1
+            parent[new_key] = parent.pop(old_key)
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as fout:
+            json.dump(anonymized_json, fout, indent=2, ensure_ascii=False)
 
     # Ancienne méthode replace_entities (maintenant redondante pour le flux principal)
     # def replace_entities(self, input_path, output_path, replacements, entities_per_block_with_offsets):

--- a/tests/cli/test_json_processor.py
+++ b/tests/cli/test_json_processor.py
@@ -1,28 +1,61 @@
 import tempfile
 from anonyfiles_cli.anonymizer.json_processor import JsonProcessor
 from pathlib import Path
+import json
+
+
+def _nested_sample() -> str:
+    return json.dumps(
+        {
+            "name": "Jean Dupont",
+            "contact": {
+                "email": "jean.dupont@example.com",
+                "phones": ["123", "456"],
+            },
+            "pets": [
+                {"type": "dog", "name": "Rex"},
+                "goldfish",
+            ],
+        }
+    )
+
 
 def test_extract_blocks_json():
-    content = '{"name": "Jean Dupont", "email": "jean.dupont@example.com"}'
+    content = _nested_sample()
     with tempfile.NamedTemporaryFile("w+", delete=False, encoding="utf-8") as tmp:
         tmp.write(content)
         tmp.flush()
         processor = JsonProcessor()
         blocks = processor.extract_blocks(tmp.name)
         assert isinstance(blocks, list)
-        assert len(blocks) == 1
-        assert "Jean Dupont" in blocks[0]
+        # 7 values should be extracted from the nested structure
+        assert len(blocks) == 7
+        assert "Jean Dupont" in blocks
+        assert "jean.dupont@example.com" in blocks
 
 def test_reconstruct_and_write_anonymized_file_json():
-    content = '{"name": "Jean Dupont", "email": "jean.dupont@example.com"}'
+    content = _nested_sample()
     with tempfile.NamedTemporaryFile("w+", delete=False, encoding="utf-8") as tmp_in, \
          tempfile.NamedTemporaryFile("r", delete=False, encoding="utf-8") as tmp_out:
         tmp_in.write(content)
         tmp_in.flush()
         processor = JsonProcessor()
         blocks = processor.extract_blocks(tmp_in.name)
-        final_blocks = [b.replace("Jean Dupont", "NOM001").replace("jean.dupont@example.com", "EMAIL001") for b in blocks]
+
+        replacements = {
+            "Jean Dupont": "NOM001",
+            "jean.dupont@example.com": "EMAIL001",
+            "Rex": "PET001",
+        }
+        final_blocks = [replacements.get(b, b) for b in blocks]
+
         processor.reconstruct_and_write_anonymized_file(Path(tmp_out.name), final_blocks, Path(tmp_in.name))
-        result = tmp_out.read()
-        assert "NOM001" in result
-        assert "EMAIL001" in result
+        with open(tmp_out.name, encoding="utf-8") as res:
+            result_json = json.load(res)
+
+        assert result_json["name"] == "NOM001"
+        assert result_json["contact"]["email"] == "EMAIL001"
+        assert result_json["pets"][0]["name"] == "PET001"
+        # keys should remain unchanged by default
+        assert "name" in result_json
+        assert "contact" in result_json


### PR DESCRIPTION
## Summary
- refactor `JsonProcessor` to parse JSON data and gather values recursively
- support optional key anonymization
- track value paths so reconstructed JSON retains original structure
- update unit tests for nested JSON structures

## Testing
- `pytest -q tests/cli/test_json_processor.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6845921b7d1c8323b8a444b9f67a0fee