### PR TITLE
Introduce deanonymization engine

### DIFF
--- a/anonyfiles_cli/anonymizer/deanonymization_engine.py
+++ b/anonyfiles_cli/anonymizer/deanonymization_engine.py
@@ -1,0 +1,53 @@
+import logging
+from pathlib import Path
+from typing import Dict, Any
+
+from .deanonymize import Deanonymizer
+
+logger = logging.getLogger(__name__)
+
+
+class DeanonymizationEngine:
+    """High level engine orchestrating the deanonymization process."""
+
+    def deanonymize(
+        self,
+        input_path: Path,
+        mapping_path: Path,
+        permissive: bool = False,
+        dry_run: bool = False,
+    ) -> Dict[str, Any]:
+        """Run deanonymization and return result information."""
+        try:
+            deanonymizer = Deanonymizer(str(mapping_path), strict=not permissive)
+            if deanonymizer.map_loading_warnings and not deanonymizer.code_to_originals:
+                warning_message = (
+                    f"Échec critique du chargement du fichier mapping '{mapping_path}'."
+                    f" Avertissements: {deanonymizer.map_loading_warnings}"
+                )
+                return {
+                    "status": "error",
+                    "error": warning_message,
+                    "restored_text": "",
+                    "report": {},
+                    "warnings": deanonymizer.map_loading_warnings,
+                }
+
+            text = input_path.read_text(encoding="utf-8")
+            restored_text, report = deanonymizer.deanonymize_text(text, dry_run=dry_run)
+            warnings = report.get("warnings_generated_during_deanonymization", [])
+            return {
+                "status": "success",
+                "restored_text": restored_text,
+                "report": report,
+                "warnings": warnings,
+            }
+        except Exception as e:
+            logger.error("Deanonymization failed", exc_info=True)
+            return {
+                "status": "error",
+                "error": str(e),
+                "restored_text": "",
+                "report": {},
+                "warnings": [],
+            }

--- a/tests/api/test_anonymization_path_safety.py
+++ b/tests/api/test_anonymization_path_safety.py
@@ -14,6 +14,15 @@ def test_anonymize_sanitizes_filenames(tmp_path):
     core_config.JOBS_DIR = tmp_path
     try:
         saved = {}
+        import importlib as _importlib
+        for mod in [
+            "anonyfiles_api.api",
+            "anonyfiles_api.routers.anonymization",
+            "anonyfiles_api.job_utils",
+        ]:
+            if mod in sys.modules:
+                del sys.modules[mod]
+        _importlib.invalidate_caches()
         sys.modules.setdefault(
             "spacy",
             importlib.util.module_from_spec(importlib.machinery.ModuleSpec("spacy", None)),

--- a/tests/api/test_deanonymization_engine.py
+++ b/tests/api/test_deanonymization_engine.py
@@ -1,0 +1,44 @@
+import shutil
+from unittest.mock import patch
+from pathlib import Path
+
+import anonyfiles_api.core_config as core_config
+from anonyfiles_api.job_utils import Job
+
+
+def test_run_deanonymization_job_sync_uses_engine(tmp_path):
+    original_jobs_dir = core_config.JOBS_DIR
+    core_config.JOBS_DIR = tmp_path
+    try:
+        input_file = tmp_path / "sample.txt"
+        input_file.write_text("{{NAME}}", encoding="utf-8")
+        map_file = tmp_path / "map.csv"
+        map_file.write_text("anonymized,original\n{{NAME}},Jean", encoding="utf-8")
+
+        job_dir = Job("job1").job_dir
+        job_dir.mkdir(parents=True, exist_ok=True)
+
+        from anonyfiles_api.routers.deanonymization import run_deanonymization_job_sync
+
+        with patch("anonyfiles_api.routers.deanonymization.DeanonymizationEngine") as Engine:
+            engine_inst = Engine.return_value
+            engine_inst.deanonymize.return_value = {
+                "status": "success",
+                "restored_text": "Jean",
+                "report": {"warnings_generated_during_deanonymization": []},
+                "warnings": [],
+            }
+            run_deanonymization_job_sync("job1", input_file, map_file, permissive=False)
+            engine_inst.deanonymize.assert_called_once_with(
+                input_path=input_file,
+                mapping_path=map_file,
+                permissive=False,
+                dry_run=False,
+            )
+
+        job_dir = Job("job1").job_dir
+        assert any(job_dir.glob(f"{input_file.stem}_deanonymise_*{input_file.suffix}"))
+        assert (job_dir / "report.json").is_file()
+    finally:
+        core_config.JOBS_DIR = original_jobs_dir
+        shutil.rmtree(tmp_path / "job1", ignore_errors=True)


### PR DESCRIPTION
## Summary
- add DeanonymizationEngine wrapper around Deanonymizer
- refactor CLI handler and API router to use DeanonymizationEngine
- add integration tests for the new engine
- adjust path safety test setup for module reloading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459548f59883239b8b2f9661351a7a