### PR TITLE
Fix Word doc anonymization formatting

### DIFF
--- a/anonyfiles_cli/anonymizer/word_processor.py
+++ b/anonyfiles_cli/anonymizer/word_processor.py
@@ -99,11 +99,24 @@ class DocxProcessor(BaseProcessor):
             if i < len(final_processed_blocks):
                 new_text = final_processed_blocks[i]
 
-            for run_element in p._element.xpath('./w:r'):
-                run_element.getparent().remove(run_element)
+            runs = list(p.runs)
 
-            if new_text.strip():
-                p.add_run(new_text)
+            if not runs:
+                if new_text:
+                    p.add_run(new_text)
+                continue
+
+            pointer = 0
+            for r in runs:
+                orig_len = len(r.text)
+                if pointer >= len(new_text):
+                    r.text = ""
+                else:
+                    r.text = new_text[pointer: pointer + orig_len]
+                pointer += orig_len
+
+            if pointer < len(new_text):
+                runs[-1].text += new_text[pointer:]
 
         output_dir = os.path.dirname(output_path)
         if output_dir and not os.path.exists(output_dir):

--- a/tests/cli/test_docx_processor.py
+++ b/tests/cli/test_docx_processor.py
@@ -1,7 +1,7 @@
 from anonyfiles_cli.anonymizer.word_processor import DocxProcessor
 from docx import Document
 from pathlib import Path
-import tempfile, os
+import tempfile
 import pytest
 
 def test_extract_blocks_docx():
@@ -35,6 +35,37 @@ def test_reconstruct_and_write_anonymized_file_docx():
     doc_result = Document(tmp_out.name)
     assert "NOM003" in doc_result.paragraphs[0].text
     assert "VILLE_Z" in doc_result.paragraphs[0].text
+
+
+def test_reconstruct_and_write_anonymized_file_docx_preserves_formatting():
+    tmp_in = tempfile.NamedTemporaryFile("w+b", delete=False, suffix=".docx")
+    tmp_out = tempfile.NamedTemporaryFile("w+b", delete=False, suffix=".docx")
+
+    doc = Document()
+    p = doc.add_paragraph()
+    r1 = p.add_run("Pierre")
+    r1.bold = True
+    p.add_run(" à ")
+    r3 = p.add_run("Paris")
+    r3.italic = True
+    doc.save(tmp_in.name)
+
+    processor = DocxProcessor()
+    blocks = processor.extract_blocks(tmp_in.name)
+    final_blocks = [b.replace("Pierre", "NOM003").replace("Paris", "VILLE_Z") for b in blocks]
+
+    processor.reconstruct_and_write_anonymized_file(
+        Path(tmp_out.name),
+        final_blocks,
+        Path(tmp_in.name),
+    )
+
+    doc_result = Document(tmp_out.name)
+    runs = doc_result.paragraphs[0].runs
+    assert runs[0].text == "NOM003"
+    assert runs[0].bold
+    assert runs[-1].text.endswith("VILLE_Z")
+    assert runs[-1].italic
 
 
 def test_reconstruct_and_write_anonymized_file_docx_mismatch():


### PR DESCRIPTION
## Summary
- modify `DocxProcessor.reconstruct_and_write_anonymized_file` to keep original run
  formatting instead of replacing entire paragraphs
- extend docx processor tests with coverage for formatting preservation

## Testing
- `pytest -q tests --ignore=anonyfiles_gui` *(fails: ModuleNotFoundError: httpx, aiofiles, typer, docx, pandas, fitz, spacy)*

------
https://chatgpt.com/codex/tasks/task_e_68459b711f588323887c5debac49dcb3