### PR TITLE
Update docs to clarify layered modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ Et comme je suis curieux et passionné, je me suis dit : autant en profiter pour
 
 ---
 
-## 🧩 Trois modules complémentaires
+## 🧩 Trois couches principales
 
-* **CLI (`anonyfiles_cli`)** : traitement en ligne de commande, configurable, robuste et multi-format.
-* **GUI (`anonyfiles_gui`)** : interface graphique moderne (Tauri + Svelte + Rust) pour une anonymisation intuitive, rapide et multiplateforme.
-* **API (`anonyfiles_api`)** : API REST (FastAPI) pour intégration dans des workflows automatisés ou systèmes tiers.
+* **`anonyfiles_core`** : bibliothèque Python contenant tout le moteur d’anonymisation et de désanonymisation.
+* **`anonyfiles_cli`** : outil en ligne de commande s’appuyant sur `anonyfiles_core` pour traiter les fichiers localement.
+* **`anonyfiles_api`** : API REST (FastAPI) qui utilise également `anonyfiles_core` afin d’exposer les mêmes fonctionnalités à distance.
+
+La GUI Tauri, située dans `anonyfiles_gui`, s’appuie elle-même sur l’API pour offrir une interface graphique.
 
 ## 🚀 Fonctionnalités principales
 
@@ -42,14 +44,40 @@ Et comme je suis curieux et passionné, je me suis dit : autant en profiter pour
 anonyfiles/
 ꜜ
 ├── README.md                  # Présent fichier
+├── anonyfiles_core/           # Bibliothèque cœur
+│   └── README.md              # Documentation du moteur
 ├── anonyfiles_cli/            # Outil CLI (Python)
 │   └── README.md              # Documentation CLI détaillée
-├── anonyfiles_gui/            # Interface graphique (Tauri / Svelte)
-│   └── README.md              # Documentation GUI détaillée
 ├── anonyfiles_api/            # API FastAPI pour appel distant
 │   └── README.md              # Documentation API détaillée
+├── anonyfiles_gui/            # Interface graphique (Tauri / Svelte)
+│   └── README.md              # Documentation GUI détaillée
 └── ...
 ```
+
+### Utilisation commune du cœur
+
+La CLI et l’API invoquent toutes deux le même moteur situé dans `anonyfiles_core`.
+Par exemple, la CLI démarre ainsi :
+
+```python
+from anonyfiles_core import AnonyfilesEngine
+
+engine = AnonyfilesEngine(config_path)
+engine.anonymize_file("input.txt")
+```
+
+De son côté, l’API réutilise exactement cette classe pour traiter les requêtes :
+
+```python
+from anonyfiles_core import AnonyfilesEngine
+
+@router.post("/anonymize")
+async def anonymize(file: UploadFile):
+    engine = AnonyfilesEngine(config_path)
+    return await engine.anonymize_async(file)
+```
+
 
 ---
 
@@ -67,6 +95,19 @@ anonyfiles/
 ```bash
 git clone https://github.com/simongrossi/anonyfiles.git
 cd anonyfiles
+```
+
+Chaque dossier (`anonyfiles_core`, `anonyfiles_cli`, `anonyfiles_api`) possède son
+propre `requirements.txt`. Vous pouvez donc installer uniquement la partie qui
+vous intéresse :
+
+```bash
+# Installation du moteur seulement
+pip install -e anonyfiles_core
+# Installation de la CLI uniquement
+pip install -r anonyfiles_cli/requirements.txt
+# Installation de l'API uniquement
+pip install -r anonyfiles_api/requirements.txt
 ```
 
 ### Installation CLI
@@ -201,6 +242,7 @@ Environment=ANONYFILES_DEFAULTS_FILE=/etc/anonyfiles/paths.toml
 
 ## 📖 Documentation détaillée
 
+* **Core :** Voir [`anonyfiles_core/README.md`](anonyfiles_core/README.md)
 * **CLI :** Voir [`anonyfiles_cli/README.md`](anonyfiles_cli/README.md)
 * **GUI :** Voir [`anonyfiles_gui/README.md`](anonyfiles_gui/README.md)
 * **API :** Voir [`anonyfiles_api/README.md`](anonyfiles_api/README.md)

--- a/anonyfiles_api/README.md
+++ b/anonyfiles_api/README.md
@@ -2,6 +2,9 @@
 # 🧩 anonyfiles_api
 
 API [FastAPI](https://fastapi.tiangolo.com/) pour le projet [anonyfiles](https://github.com/simongrossi/anonyfiles)
+reposant sur le moteur commun `anonyfiles_core`. L’API expose ainsi les mêmes
+Ce projet est structuré en trois couches : `anonyfiles_core`, `anonyfiles_cli` et `anonyfiles_api`.
+fonctionnalités que la CLI mais via des endpoints REST.
 
 ---
 
@@ -33,10 +36,10 @@ cd anonyfiles_api
 pip install -r ../requirements.txt
 ```
 
-Ou en local :
+Ou installation indépendante :
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements.txt  # installe également anonyfiles_core
 ```
 
 ---
@@ -128,6 +131,17 @@ anonyfiles_api/
     ├── deanonymization.py   # Endpoint /deanonymize
     ├── files.py             # Téléchargement des fichiers anonymisés
     └── jobs.py              # Suppression et gestion avancée des jobs
+```
+
+Extrait montrant l’utilisation du moteur partagé :
+
+```python
+from anonyfiles_core import AnonyfilesEngine
+
+@router.post("/anonymize")
+async def anonymize(file: UploadFile):
+    engine = AnonyfilesEngine(config_path)
+    return await engine.anonymize_async(file)
 ```
 
 ---

--- a/anonyfiles_cli/README.md
+++ b/anonyfiles_cli/README.md
@@ -3,6 +3,9 @@
 
 **Anonyfiles CLI** est l’outil en ligne de commande du projet [Anonyfiles](https://github.com/simongrossi/anonyfiles), conçu pour **anonymiser et désanonymiser des documents texte, tableurs et fichiers bureautiques**.
 
+Il repose sur la bibliothèque `anonyfiles_core`, laquelle contient tout le moteur d’anonymisation. La CLI n’est donc qu’une interface qui appelle ce cœur commun.
+Le projet est composé de trois couches : `anonyfiles_core` (moteur), `anonyfiles_cli` (interface en ligne) et `anonyfiles_api` (service REST).
+
 Il s’appuie sur le NLP (spaCy), une configuration flexible en YAML, et des règles personnalisables pour **garantir la confidentialité des données sensibles**.
 
 ## **🚀 Fonctionnalités principales**
@@ -43,7 +46,8 @@ Il s’appuie sur le NLP (spaCy), une configuration flexible en YAML, et des rè
 
 git clone https://github.com/simongrossi/anonyfiles.git
 cd anonyfiles/anonyfiles\_cli
-pip install -r requirements.txt
+# Installation indépendante de la CLI
+pip install -r requirements.txt  # installe aussi anonyfiles_core en dépendance
 # Installer le modèle spaCy séparément après les dépendances
 python3 -m spacy download fr\_core\_news\_md
 
@@ -109,6 +113,16 @@ Le projet anonyfiles\_cli est conçu de manière modulaire, avec une séparation
 python -m anonyfiles\_cli.main anonymize anonyfiles\_cli/input.txt
 
 Le résultat affichera un Job ID (un timestamp) et le chemin vers les fichiers générés dans un sous-dossier de anonyfiles\_outputs/runs/.
+
+En interne, cette commande instancie le moteur partagé :
+
+```python
+from anonyfiles_core import AnonyfilesEngine
+
+engine = AnonyfilesEngine(config_path)
+engine.anonymize_file("input.txt")
+```
+
 
 ### **▶️ Exemple avancé d'anonymisation**
 

--- a/anonyfiles_core/README.md
+++ b/anonyfiles_core/README.md
@@ -1,0 +1,10 @@
+# anonyfiles_core
+
+`anonyfiles_core` contient la logique principale d'anonymisation et de désanonymisation utilisée par l'ensemble du projet. Cette bibliothèque est indépendante et peut être installée seule pour être réutilisée dans d'autres applications.
+
+Elle est appelée directement par:
+
+- `anonyfiles_cli` pour les traitements en ligne de commande.
+- `anonyfiles_api` pour exposer ces traitements via HTTP.
+
+Chaque module possède son fichier `requirements.txt` afin de permettre une installation séparée selon vos besoins.


### PR DESCRIPTION
## Summary
- document three-layer architecture across READMEs
- show how CLI and API call `anonyfiles_core`
- note independent installation for each component

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6845b39d1874832388f19b38ca847c8b