### PR TITLE
Implement WebSocket job status endpoint

### DIFF
--- a/anonyfiles_api/README.md
+++ b/anonyfiles_api/README.md
@@ -65,6 +65,7 @@ uvicorn anonyfiles_api.api:app --reload --host 0.0.0.0 --port 8000
 |---------|------------------------------|--------------------------------------------------|
 | POST    | `/anonymize`                 | Anonymise un fichier ou texte (asynchrone)       |
 | GET     | `/anonymize_status/{job_id}` | Vérifie le statut d’un job                       |
+| WS      | `/ws/{job_id}`               | Statut temps réel d'un job (WebSocket) |
 | POST    | `/deanonymize`               | Désanonymise un texte en utilisant un mapping    |
 | GET     | `/health`                    | Vérifie le bon fonctionnement de l’API           |
 
@@ -116,6 +117,10 @@ Retourne le statut du job :
   ]
 }
 ```
+### `WS /ws/{job_id}`
+
+Ouvre une connexion WebSocket pour suivre en temps réel le statut d'un job. La connexion se ferme lorsque le statut devient `finished` ou `error`.
+
 
 ---
 

--- a/anonyfiles_api/api.py
+++ b/anonyfiles_api/api.py
@@ -8,7 +8,7 @@ import sys
 import yaml # Importer yaml ici
 from typing import Optional, Dict, Any # Pour load_config_for_api
 
-from .routers import anonymization, deanonymization, files, jobs, health
+from .routers import anonymization, deanonymization, files, jobs, health, websocket_status
 from .core_config import logger, CONFIG_TEMPLATE_PATH, JOBS_DIR
 
 # Plus besoin d'importer load_config_api_safe depuis anonyfiles_cli.main
@@ -83,6 +83,7 @@ app.include_router(deanonymization.router)
 app.include_router(files.router)
 app.include_router(jobs.router)
 app.include_router(health.router)
+app.include_router(websocket_status.router)
 
 @app.get("/", tags=["Racine"])
 async def read_root():

--- a/anonyfiles_api/routers/websocket_status.py
+++ b/anonyfiles_api/routers/websocket_status.py
@@ -1,0 +1,37 @@
+# anonyfiles/anonyfiles_api/routers/websocket_status.py
+
+import asyncio
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from ..job_utils import Job
+from ..core_config import logger
+
+router = APIRouter()
+
+@router.websocket("/ws/{job_id}")
+async def websocket_job_status(websocket: WebSocket, job_id: str) -> None:
+    """Envoie en temps réel le statut d'un job via WebSocket."""
+    await websocket.accept()
+    job = Job(job_id)
+    if not await job.check_exists_async():
+        await websocket.close(code=1008)
+        return
+
+    last_payload = None
+    try:
+        while True:
+            status_payload = await job.get_status_async()
+            if status_payload is None:
+                status_payload = {"status": "error", "error": "status not found"}
+                await websocket.send_json(status_payload)
+                break
+            if status_payload != last_payload:
+                await websocket.send_json(status_payload)
+                last_payload = status_payload
+            if status_payload.get("status") in {"finished", "error"}:
+                break
+            await asyncio.sleep(1)
+    except WebSocketDisconnect:
+        logger.info(f"Client WebSocket déconnecté pour la tâche {job_id}")
+    finally:
+        await websocket.close()


### PR DESCRIPTION
## Summary
- add websocket router for real-time job status updates
- plug websocket router into API
- document `/ws/{job_id}` endpoint in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6845b90d1c008323985191b7b61763d1