### PR TITLE
Make jobs directory configurable via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ définir (par exemple dans `/etc/default/anonyfiles-api`) :
 - `ANONYFILES_HOME` : répertoire racine du projet
 - `ANONYFILES_HOST` : adresse d'écoute d'uvicorn (ex. `127.0.0.1`)
 - `ANONYFILES_PORT` : port d'écoute de l'API (ex. `8000`)
+- `ANONYFILES_JOBS_DIR` : répertoire des jobs (défaut `jobs`)
 
 ---
 

--- a/anonyfiles_api/core_config.py
+++ b/anonyfiles_api/core_config.py
@@ -1,6 +1,7 @@
 # anonyfiles_api/core_config.py
 import logging
 import sys
+import os
 from pathlib import Path
 # from typing import Optional, Dict, Any # Plus nécessaire ici
 
@@ -21,7 +22,7 @@ CONFIG_TEMPLATE_PATH = (
 )
 
 # Répertoire des tâches (Jobs)
-JOBS_DIR = Path("jobs")
+JOBS_DIR = Path(os.environ.get("ANONYFILES_JOBS_DIR", "jobs"))
 
 # Racine pour les noms de fichiers d'entrée d'une tâche
 BASE_INPUT_STEM_FOR_JOB_FILES = "input"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -33,6 +33,7 @@ Les variables d'environnement à définir (dans `/etc/default/anonyfiles-api` pa
 - `ANONYFILES_HOME` : chemin du projet
 - `ANONYFILES_HOST` : adresse d'écoute (ex. `127.0.0.1`)
 - `ANONYFILES_PORT` : port d'écoute (ex. `8000`)
+- `ANONYFILES_JOBS_DIR` : répertoire des jobs (défaut `jobs`)
 
 ## 📦 Déploiement via Nixpacks
 


### PR DESCRIPTION
## Summary
- read ANONYFILES_JOBS_DIR env var in core_config
- document ANONYFILES_JOBS_DIR in README and deploy guide

## Testing
- `pytest tests/unit/test_replacer.py::test_generate_code_defaults -q` *(fails: ModuleNotFoundError: No module named 'spacy')*

------
https://chatgpt.com/codex/tasks/task_e_6845bc7d989083239f94c42c6cbdeae8