### PR TITLE
Add async wrapper and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,12 @@ from anonyfiles_core import AnonyfilesEngine
 @router.post("/anonymize")
 async def anonymize(file: UploadFile):
     engine = AnonyfilesEngine(config_path)
+    # temporary async wrapper around `anonymize`
+
     return await engine.anonymize_async(file)
 ```
+Cet appel asynchrone utilise simplement ``asyncio.to_thread`` pour exécuter la
+méthode de base de façon non bloquante.
 
 
 ---

--- a/anonyfiles_api/README.md
+++ b/anonyfiles_api/README.md
@@ -147,8 +147,12 @@ from anonyfiles_core import AnonyfilesEngine
 @router.post("/anonymize")
 async def anonymize(file: UploadFile):
     engine = AnonyfilesEngine(config_path)
+    # temporary async wrapper around `anonymize`
+
     return await engine.anonymize_async(file)
 ```
+Cet appel asynchrone utilise simplement ``asyncio.to_thread`` pour exécuter la
+méthode de base de façon non bloquante.
 
 ---
 

--- a/anonyfiles_core/anonymizer/engine.py
+++ b/anonyfiles_core/anonymizer/engine.py
@@ -4,6 +4,7 @@ import csv
 from pathlib import Path
 from typing import Optional, List, Dict, Any, Tuple
 import logging
+import asyncio
 
 from .spacy_engine import SpaCyEngine
 from .replacer import ReplacementSession
@@ -225,3 +226,12 @@ class AnonyfilesEngine:
             "audit_log": self.audit_logger.summary(),
             "total_replacements": total_replacements_logged,
         }
+
+    async def anonymize_async(self, *args, **kwargs) -> Dict[str, Any]:
+        """Asynchronous wrapper around :meth:`anonymize`.
+
+        This helper uses ``asyncio.to_thread`` to run the synchronous
+        ``anonymize`` method in a thread until a full asynchronous
+        refactor is completed.
+        """
+        return await asyncio.to_thread(self.anonymize, *args, **kwargs)


### PR DESCRIPTION
## Summary
- add `anonymize_async` to `AnonyfilesEngine` using `asyncio.to_thread`
- document async wrapper in README
- document async wrapper in API README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6845c974aaac8323aa4d798c00536747