### PR TITLE
Add pytest.ini to focus on tests directory

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests


### PR DESCRIPTION
## Summary
- configure pytest to only collect tests from the `tests` directory

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845cdbdfb608323a22121653345a2de