### PR TITLE
Add importorskip to optional dependency tests

### DIFF
--- a/examples/test_cmd.py
+++ b/examples/test_cmd.py
@@ -1,4 +1,6 @@
 # test_cmd.py
+import pytest
+pytest.importorskip("typer")
 import typer
 
 app_test = typer.Typer()

--- a/tests/api/test_anonymization_path_safety.py
+++ b/tests/api/test_anonymization_path_safety.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("httpx")
 import shutil
 import importlib
 import sys

--- a/tests/api/test_deanonymization_engine.py
+++ b/tests/api/test_deanonymization_engine.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("aiofiles")
 import shutil
 from unittest.mock import patch
 from pathlib import Path

--- a/tests/api/test_deanonymization_path_safety.py
+++ b/tests/api/test_deanonymization_path_safety.py
@@ -1,9 +1,10 @@
-import pytest; pytest.skip("unstable in CI", allow_module_level=True)
+import pytest
+pytest.skip("unstable in CI", allow_module_level=True)
+pytest.importorskip("httpx")
 import shutil
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 from fastapi.testclient import TestClient
 
 import importlib

--- a/tests/api/test_deanonymization_streaming.py
+++ b/tests/api/test_deanonymization_streaming.py
@@ -1,4 +1,6 @@
-import pytest; pytest.skip("unstable in CI", allow_module_level=True)
+import pytest
+pytest.skip("unstable in CI", allow_module_level=True)
+pytest.importorskip("httpx")
 import shutil
 import importlib
 import sys

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
 import importlib
 import sys

--- a/tests/api/test_websocket_status.py
+++ b/tests/api/test_websocket_status.py
@@ -5,6 +5,7 @@ import sys
 from unittest.mock import patch
 
 import pytest
+pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 

--- a/tests/cli/test_cli_e2e.py
+++ b/tests/cli/test_cli_e2e.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("typer")
 from typer.testing import CliRunner
 from pathlib import Path
 from types import SimpleNamespace

--- a/tests/cli/test_csv_processor.py
+++ b/tests/cli/test_csv_processor.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("spacy")
 import tempfile
 import csv
 from pathlib import Path

--- a/tests/cli/test_docx_processor.py
+++ b/tests/cli/test_docx_processor.py
@@ -1,8 +1,8 @@
+import pytest
+Document = pytest.importorskip("docx").Document
 from anonyfiles_core.anonymizer.word_processor import DocxProcessor
-from docx import Document
 from pathlib import Path
 import tempfile
-import pytest
 
 def test_extract_blocks_docx():
     tmp = tempfile.NamedTemporaryFile("w+b", delete=False, suffix=".docx")

--- a/tests/cli/test_excel_processor.py
+++ b/tests/cli/test_excel_processor.py
@@ -1,8 +1,8 @@
+import pytest
+pd = pytest.importorskip("pandas")
 import tempfile
-import pandas as pd
 from anonyfiles_core.anonymizer.excel_processor import ExcelProcessor
 from pathlib import Path
-import pytest
 
 def test_extract_blocks_excel():
     tmp = tempfile.NamedTemporaryFile("w+b", delete=False, suffix=".xlsx")

--- a/tests/cli/test_json_processor.py
+++ b/tests/cli/test_json_processor.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("spacy")
 import tempfile
 from anonyfiles_core.anonymizer.json_processor import JsonProcessor
 from pathlib import Path

--- a/tests/cli/test_pdf_processor.py
+++ b/tests/cli/test_pdf_processor.py
@@ -1,6 +1,7 @@
+import pytest
+fitz = pytest.importorskip("fitz")
 import tempfile
 from pathlib import Path
-import fitz
 
 from anonyfiles_core.anonymizer.pdf_processor import PdfProcessor
 

--- a/tests/cli/test_txt_processor.py
+++ b/tests/cli/test_txt_processor.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("spacy")
 import tempfile
 from anonyfiles_core.anonymizer.txt_processor import TxtProcessor
 from pathlib import Path

--- a/tests/unit/test_replacer.py
+++ b/tests/unit/test_replacer.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("spacy")
 from anonyfiles_core.anonymizer.replacer import ReplacementSession
 
 

--- a/tests/unit/test_spacy_engine.py
+++ b/tests/unit/test_spacy_engine.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("spacy")
 import importlib
 from types import SimpleNamespace
 from unittest.mock import patch


### PR DESCRIPTION
## Summary
- skip optional dependencies in CLI and API tests using `pytest.importorskip`
- avoid importing heavy modules when optional deps aren't installed

## Testing
- `pytest -q --ignore=anonyfiles_gui`

------
https://chatgpt.com/codex/tasks/task_e_6845d18231a483238a165bb251e996e3