### PR TITLE
Add Railway deploy workflow

### DIFF
--- a/.github/workflows/railway.yml
+++ b/.github/workflows/railway.yml
@@ -1,0 +1,23 @@
+name: Deploy API to Railway
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements-full.txt
+          pip install -e .
+      - name: Deploy to Railway
+        uses: railwayapp/railway@v1
+        with:
+          apiToken: ${{ secrets.RAILWAY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for deploying the API to Railway

## Testing
- `pytest -q tests/unit/test_replacer.py` *(fails: ModuleNotFoundError: No module named 'aiofiles')*

------
https://chatgpt.com/codex/tasks/task_e_68460fba6a908323b748f8b989857b1e