### PR TITLE
Add Railway config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,11 @@ définir (par exemple dans `/etc/default/anonyfiles-api`) :
 - `ANONYFILES_PORT` : port d'écoute de l'API (ex. `8000`)
 - `ANONYFILES_JOBS_DIR` : répertoire des jobs (défaut `jobs`)
 
+Un fichier `railway.json.example` est fourni à la racine pour simplifier un
+déploiement via Railway. Copiez-le en `railway.json` puis ajustez les valeurs
+(nom du service, chemin de santé, variables d'environnement...) avant de
+lancer votre déploiement.
+
 ---
 
 ## 🤝 Contribuer

--- a/railway.json.example
+++ b/railway.json.example
@@ -1,0 +1,9 @@
+{
+  "service": "anonyfiles-api",
+  "healthcheckPath": "/health",
+  "envs": {
+    "ANONYFILES_HOST": "0.0.0.0",
+    "ANONYFILES_PORT": "8000",
+    "ANONYFILES_JOBS_DIR": "jobs"
+  }
+}


### PR DESCRIPTION
## Summary
- add a `railway.json.example` with basic service configuration
- document how to use the example in the deployment section of the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68461324e4f08323a128a202bede1248