### PR TITLE
Add request flow documentation

### DIFF
--- a/docs/request_flow.md
+++ b/docs/request_flow.md
@@ -1,0 +1,63 @@
+# Architecture et flux de requête
+
+Ce document décrit le chemin complet d'une requête depuis le client jusqu'au stockage des résultats ainsi que les relations entre la CLI, l'API et la GUI.
+
+## Modules principaux
+
+- **anonyfiles_core** : moteur d'anonymisation commun.
+- **anonyfiles_cli** : outil en ligne de commande utilisant `anonyfiles_core`.
+- **anonyfiles_api** : API FastAPI qui réutilise également `anonyfiles_core`.
+- **anonyfiles_gui** : interface graphique Tauri qui s'appuie sur la CLI.
+
+Extrait du `README.md` montrant cette organisation :
+
+```text
+* `anonyfiles_cli` : outil en ligne de commande s’appuyant sur `anonyfiles_core` pour traiter les fichiers localement.
+* `anonyfiles_api` : API REST (FastAPI) qui utilise également `anonyfiles_core` afin d’exposer les mêmes fonctionnalités à distance.
+La GUI Tauri, située dans `anonyfiles_gui`, s’appuie elle-même sur l’API pour offrir une interface graphique.
+```
+
+## Flux complet d'une requête d'anonymisation
+
+1. **Client** : envoie une requête `POST /anonymize` avec le fichier et les options.
+2. **API FastAPI** : sauvegarde le fichier dans un dossier de job (`jobs/<job_id>`), écrit `status.json` et lance `run_anonymization_job_sync` en tâche de fond.
+3. **Moteur `AnonyfilesEngine`** : lit le fichier, applique les règles d'anonymisation, écrit les fichiers de sortie (texte anonymisé, mapping CSV, log CSV, audit).
+4. **Job utils** : met à jour `status.json` à `finished` ou `error` et stocke le journal d'audit.
+5. **Client** : récupère le statut via `GET /anonymize_status/{job_id}` ou la WebSocket `/ws/{job_id}` puis télécharge éventuellement les fichiers avec `GET /files/{job_id}/{file_key}`.
+
+Les fichiers générés sont stockés dans le dossier `jobs/` (aucune base de données n'est utilisée par défaut).
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant A as API FastAPI
+    participant J as Job handler
+    participant E as AnonyfilesEngine
+    participant F as Jobs directory
+
+    C->>A: POST /anonymize (fichier)
+    A->>J: crée job + status pending
+    J->>E: lance anonymisation
+    E->>F: écrit fichiers de sortie
+    E-->>J: résultat (success ou error)
+    J->>F: met à jour status.json
+    C->>A: GET /anonymize_status/{job_id}
+    A->>F: lit status.json
+    A-->>C: statut + contenus
+```
+
+## Relations CLI, API et GUI
+
+```mermaid
+graph TD
+    subgraph Coeur
+        CORE["anonyfiles_core"]
+    end
+
+    CLI["anonyfiles_cli"] -->|utilise| CORE
+    API["anonyfiles_api"] -->|utilise| CORE
+    GUI["anonyfiles_gui"] -->|appelle la CLI| CLI
+    GUI -. optionnel .-> API
+```
+
+La CLI et l’API partagent le même moteur (`anonyfiles_core`). La GUI interagit principalement avec la CLI pour réaliser l’anonymisation localement mais peut aussi appeler l’API si un serveur distant est disponible.


### PR DESCRIPTION
## Summary
- add a new documentation file describing request flow and module relationships

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684615cf98f883238406aa118255cd9b