### PR TITLE
Update start commands for Railway

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn anonyfiles_api.api:app --host 0.0.0.0 --port $PORT
+web: bash -c 'uvicorn anonyfiles_api.api:app --host 0.0.0.0 --port ${PORT:-8000}'

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -14,8 +14,10 @@ docker run -p 8000:8000 anonyfiles
 Pour certains hébergeurs (Heroku, Scalingo...), le `Procfile` fournit la commande de démarrage :
 
 ```procfile
-web: uvicorn anonyfiles_api.api:app --host 0.0.0.0 --port $PORT
+web: bash -c 'uvicorn anonyfiles_api.api:app --host 0.0.0.0 --port ${PORT:-8000}'
 ```
+
+Cette commande nécessite que la variable d'environnement `PORT` soit définie par la plateforme (Railway le fait automatiquement). À défaut, Uvicorn démarrera sur le port `8000`.
 
 ## 🛠️ Service systemd
 
@@ -44,7 +46,7 @@ nixpacks build . --name anonyfiles
 nixpacks run .
 ```
 
-Ces commandes créent une image contenant l'API puis la démarrent avec le même ordre que défini dans le `Procfile`.
+Ces commandes créent une image contenant l'API puis la démarrent avec le même ordre que défini dans le `Procfile`. Assurez-vous que la variable `PORT` est disponible dans l'environnement pour que Uvicorn écoute sur le bon port.
 
 ## 🚄 Déploiement continu via Railway
 

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -13,4 +13,4 @@ commands = [
 commands = []
 
 [phases.start]
-command = "uvicorn anonyfiles_api.api:app --host 0.0.0.0 --port $PORT"
+command = "bash -c 'uvicorn anonyfiles_api.api:app --host 0.0.0.0 --port ${PORT:-8000}'"


### PR DESCRIPTION
## Summary
- set up `PORT` fallback in `nixpacks.toml` start command
- launch uvicorn through a shell in the Procfile
- document the new command and `PORT` variable in deploy README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846cd4a11d0832393d73212e626b59a