### PR TITLE
Modify compile_requirements.sh for path replacement

### DIFF
--- a/compile_requirements.sh
+++ b/compile_requirements.sh
@@ -2,4 +2,7 @@
 # Compile project dependencies using pip-tools
 set -e
 pip-compile requirements.in
+# Replace any occurrence of "file://$PWD" in the generated file with a
+# relative path so requirements.txt stays portable.
+sed -i -e "s|file://$(pwd)/|./|g" -e "s|file://$(pwd)|.|g" requirements.txt
 pip-compile requirements-test.in


### PR DESCRIPTION
## Summary
- replace editable path with a relative path after `pip-compile`
- document path replacement in `compile_requirements.sh`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68470993b0b483239490d6b3632fcc3e