### PR TITLE
Fix Railway port variable

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bash -c 'uvicorn anonyfiles_api.api:app --host 0.0.0.0 --port ${PORT:-8000}'
+web: uvicorn anonyfiles_api.api:app --host 0.0.0.0 --port ${PORT:-8000}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -14,7 +14,7 @@ docker run -p 8000:8000 anonyfiles
 Pour certains hébergeurs (Heroku, Scalingo...), le `Procfile` fournit la commande de démarrage :
 
 ```procfile
-web: bash -c 'uvicorn anonyfiles_api.api:app --host 0.0.0.0 --port ${PORT:-8000}'
+web: uvicorn anonyfiles_api.api:app --host 0.0.0.0 --port ${PORT:-8000}
 ```
 
 Cette commande nécessite que la variable d'environnement `PORT` soit définie par la plateforme (Railway le fait automatiquement). À défaut, Uvicorn démarrera sur le port `8000`.

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -13,4 +13,4 @@ commands = [
 commands = []
 
 [phases.start]
-command = "bash -c 'uvicorn anonyfiles_api.api:app --host 0.0.0.0 --port ${PORT:-8000}'"
+command = "uvicorn anonyfiles_api.api:app --host 0.0.0.0 --port ${PORT:-8000}"


### PR DESCRIPTION
## Summary
- update start command in Procfile so $PORT is expanded correctly
- update nixpacks config to match
- document the corrected Procfile entry

## Testing
- `pytest -k "not gui" -q`

------
https://chatgpt.com/codex/tasks/task_e_68470d39fe148323a6ab99a337268b5d