### PR TITLE
Add verbose logging flag support

### DIFF
--- a/anonyfiles_cli/main.py
+++ b/anonyfiles_cli/main.py
@@ -35,7 +35,7 @@ def main_callback(
     S'assure qu'un fichier de configuration utilisateur par défaut existe au démarrage de l'application
     s'il n'est pas déjà présent.
     """
-    logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO)
+    logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO, force=True)
     if verbose:
         logging.debug("Verbose mode enabled")
     CLIUsageLogger.VERBOSE = verbose

--- a/tests/cli/test_cli_e2e.py
+++ b/tests/cli/test_cli_e2e.py
@@ -155,4 +155,4 @@ def test_cli_verbose_outputs_debug():
     runner = CliRunner()
     result = runner.invoke(app, ["--verbose", "config", "validate-config", str(cfg)])
     assert result.exit_code == 0
-    assert "Verbose mode enabled" in result.output
+    assert "DEBUG:root:Verbose mode enabled" in result.output


### PR DESCRIPTION
## Summary
- force logging level when `--verbose` is passed
- adjust CLI E2E test to check debug output

## Testing
- `pytest tests/cli/test_cli_e2e.py::test_cli_verbose_outputs_debug -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a111c9108323b4ac0198afa3eba1