### PR TITLE
Add command info to error logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,13 @@ Ou dans un service Systemd :
 Environment=ANONYFILES_DEFAULTS_FILE=/etc/anonyfiles/paths.toml
 ```
 
+## 📝 Format des logs CLI
+
+Chaque entrée du fichier `cli_audit_log.jsonl` est une ligne JSON.
+En plus des champs existants (`timestamp`, `success`, `error`, etc.),
+les erreurs enregistrent désormais le `command` exécuté et les `arguments`
+passés à la CLI lorsque ces informations sont disponibles.
+
 ## 📖 Documentation détaillée
 
 * **Core :** Voir [`anonyfiles_core/README.md`](anonyfiles_core/README.md)

--- a/anonyfiles_cli/cli_logger.py
+++ b/anonyfiles_cli/cli_logger.py
@@ -4,7 +4,7 @@ import datetime
 import json
 import os
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 import typer
 from pathlib import Path
 import traceback
@@ -36,14 +36,25 @@ class CLIUsageLogger:
             logger.error("[CLIUsageLogger] Erreur d’écriture log: %s", e)
 
     @classmethod
-    def log_error(cls, context: str, exc: Exception):
+    def log_error(
+        cls,
+        context: str,
+        exc: Exception,
+        *,
+        command: Optional[str] = None,
+        args: Optional[Dict[str, Any]] = None,
+    ):
         entry: Dict[str, Any] = {
             "timestamp": datetime.datetime.utcnow().isoformat(),
             "error": str(exc),
             "traceback": traceback.format_exc(),
             "context": context,
         }
-        if cls.VERBOSE:
+        if command is not None:
+            entry["command"] = command
+        if args is not None:
+            entry["arguments"] = args
+        elif cls.VERBOSE:
             try:
                 ctx = typer.get_current_context()
                 entry["command"] = ctx.command_path

--- a/anonyfiles_cli/ui/console_display.py
+++ b/anonyfiles_cli/ui/console_display.py
@@ -3,6 +3,7 @@
 import traceback
 from pathlib import Path
 from typing import Dict, Any, Optional
+import typer
 
 from rich.console import Console
 from rich.panel import Panel
@@ -86,22 +87,35 @@ class ConsoleDisplay:
         :param context: Contexte de l'erreur (où elle s'est produite).
         """
         from ..cli_logger import CLIUsageLogger
+        command_name = None
+        params = None
+        try:
+            ctx = typer.get_current_context()
+            command_name = ctx.command_path
+            params = ctx.params
+        except Exception:
+            pass
 
         if isinstance(error, ConfigurationError):
             self.console.print(f"⚙️  [yellow]Erreur de configuration:[/yellow] {error}")
-            CLIUsageLogger.log_error(context, error)
+            CLIUsageLogger.log_error(context, error, command=command_name, args=params)
         elif isinstance(error, FileIOError):
             self.console.print(f"📂 [red]Erreur fichier:[/red] {error}")
-            CLIUsageLogger.log_error(context, error)
+            CLIUsageLogger.log_error(context, error, command=command_name, args=params)
         elif isinstance(error, ProcessingError):
             self.console.print(f"⚠️  [red]Erreur de traitement:[/red] {error}")
-            CLIUsageLogger.log_error(context, error)
+            CLIUsageLogger.log_error(context, error, command=command_name, args=params)
         elif isinstance(error, AnonyfilesError):
             self.console.print(f"❌ [red]Erreur :[/red] {error}")
-            CLIUsageLogger.log_error(context, error)
+            CLIUsageLogger.log_error(context, error, command=command_name, args=params)
         else:
             self.console.print(f"❌ [red]Erreur inattendue:[/red] {error}")
             self.console.print(f"[red]Contexte de l'erreur: {context}[/red]")
-            CLIUsageLogger.log_error(f"{context}_unexpected_error", error)
+            CLIUsageLogger.log_error(
+                f"{context}_unexpected_error",
+                error,
+                command=command_name,
+                args=params,
+            )
             self.console.print("[red]Veuillez signaler ce bug si cela persiste.[/red]")
             self.console.print(traceback.format_exc(), style="dim red")

--- a/anonyfiles_core/anonymizer/run_logger.py
+++ b/anonyfiles_core/anonymizer/run_logger.py
@@ -18,7 +18,9 @@ def log_run_event(
     total_replacements: int,
     audit_log: Optional[list],
     status: str,
-    error: Optional[str] = None
+    error: Optional[str] = None,
+    command: Optional[str] = None,
+    args: Optional[Dict[str, Any]] = None,
 ) -> None:
     """
     Log une session (run) d'anonymisation/désanonymisation de façon centralisée et cohérente.
@@ -45,5 +47,7 @@ def log_run_event(
         "total_replacements": total_replacements,
         "rules_applied": audit_log or [],
         "success": status == "success",
-        "error": error
+        "error": error,
+        "command": command,
+        "arguments": args or {},
     })

--- a/tests/unit/test_console_display.py
+++ b/tests/unit/test_console_display.py
@@ -6,7 +6,7 @@ from anonyfiles_cli.exceptions import ConfigurationError, FileIOError, Processin
 
 class DummyLogger:
     @staticmethod
-    def log_error(context, exc):
+    def log_error(context, exc, *, command=None, args=None):
         pass
 
 


### PR DESCRIPTION
## Summary
- capture command name and parameters in CLI log_error
- supply context when ConsoleDisplay reports an error
- extend run_logger to handle command and argument fields
- document log format in the README
- adjust unit tests for new log_error signature

## Testing
- `pytest tests/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_6849a88f59088323a6ac97b9e60b02c3