### PR TITLE
Wrap spaCy load errors

### DIFF
--- a/anonyfiles_core/anonymizer/spacy_engine.py
+++ b/anonyfiles_core/anonymizer/spacy_engine.py
@@ -35,11 +35,10 @@ def _load_spacy_model_cached(model_name: str):
     try:
         return spacy.load(model_name)
     except Exception as e:
+        install_cmd = f"python -m spacy download {model_name}"
         raise ConfigurationError(
-            f"Could not load spaCy model '{model_name}'. "
-            f"Please install it with 'python -m spacy download {model_name}'. "
-            f"Original error: {e}"
-        )
+            f"Could not load spaCy model '{model_name}'. Install it using: {install_cmd}. Original error: {e}"
+        ) from e
 
 
 class SpaCyEngine:

--- a/tests/unit/test_spacy_engine.py
+++ b/tests/unit/test_spacy_engine.py
@@ -31,5 +31,7 @@ def test_load_model_failure_raises_configuration_error():
         raise OSError("model missing")
 
     with patch.object(spacy_engine, "spacy", SimpleNamespace(load=fail_load)):
-        with pytest.raises(ConfigurationError):
+        with pytest.raises(ConfigurationError) as exc:
             spacy_engine.SpaCyEngine(model="missing")
+    msg = str(exc.value)
+    assert "python -m spacy download missing" in msg


### PR DESCRIPTION
## Summary
- clarify spaCy model loading failure with installation hint
- adjust CLI bundle test to not expect log.csv when no entities
- expose spacy install hint in engine test
- check cached spaCy model in CLI test

## Testing
- `pytest tests/unit/test_spacy_engine.py::test_load_model_failure_raises_configuration_error -q`
- `pytest tests/cli/test_cli_e2e.py::test_cli_anonymize_bundle -q`
- `pytest tests/cli/test_cli_e2e.py::test_cli_missing_spacy_model -q`
- `pytest tests/unit tests/cli tests/api -q`

------
https://chatgpt.com/codex/tasks/task_e_6849aaa0ad78832399f73d6887145abe