### PR TITLE
Implement early validation for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ La GUI Tauri, située dans `anonyfiles_gui`, s’appuie elle-même sur l’API p
 * Prise en charge du français (et autres langues via spaCy)
 * **Asynchrone via l’API REST** (suivi via `job_id`)
 * **Portable** : aucun chemin codé en dur, multiplateforme (Windows, macOS, Linux)
+* **Validation rapide** : les chemins, la configuration et la présence du modèle spaCy sont vérifiés avant de lancer le traitement
 
 ---
 

--- a/anonyfiles_cli/handlers/anonymize_handler.py
+++ b/anonyfiles_cli/handlers/anonymize_handler.py
@@ -76,6 +76,7 @@ class AnonymizeHandler:
 
             # 1. Configuration
             effective_config = ConfigManager.get_effective_config(config_path)
+            ValidationManager.ensure_spacy_model(effective_config.get("spacy_model", "fr_core_news_md"))
             self.console.console.print("🔧 Configuration chargée et validée.")
 
             # 2. Résolution des chemins

--- a/anonyfiles_cli/managers/config_manager.py
+++ b/anonyfiles_cli/managers/config_manager.py
@@ -77,6 +77,12 @@ class ConfigManager:
             cli_config = ValidationManager.load_and_validate_config(cli_provided_config_path)
             merged_config.update(cli_config)
 
+        # Validation finale de la configuration fusionnée
+        try:
+            ValidationManager.validate_config_dict(merged_config)
+        except ConfigurationError as e:
+            raise ConfigurationError(f"Configuration finale invalide: {e}") from e
+
         return merged_config
 
     @classmethod

--- a/anonyfiles_cli/managers/validation_manager.py
+++ b/anonyfiles_cli/managers/validation_manager.py
@@ -118,3 +118,20 @@ class ValidationManager:
             logger.info("Continuant avec l'écrasement des fichiers existants.") # Modifié pour utiliser logger.info
         elif existing_files and force:
             logger.warning("⚠️  Les fichiers de sortie existants seront écrasés (mode --force).") # Modifié pour utiliser logger.warning
+
+    @staticmethod
+    def validate_config_dict(config: Dict[str, Any]) -> None:
+        """Valide un dictionnaire de configuration selon ``SCHEMA``."""
+        v = Validator(SCHEMA)
+        if not v.validate(config):
+            raise ConfigurationError(f"Configuration YAML invalide : {v.errors}")
+
+    @staticmethod
+    def ensure_spacy_model(model_name: str) -> None:
+        """Vérifie que le modèle spaCy demandé est installé."""
+        import importlib
+        if importlib.util.find_spec(model_name) is None:
+            raise ConfigurationError(
+                f"Le modèle spaCy '{model_name}' est introuvable. "
+                f"Installez-le avec 'python -m spacy download {model_name}'."
+            )


### PR DESCRIPTION
## Summary
- check config dictionaries and spaCy models early
- validate merged configuration in `ConfigManager`
- ensure spaCy model availability before launching anonymization
- document fail-fast validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b0a49e908323bded0a690a9bb6f6