### PR TITLE
Update config schema and tests

### DIFF
--- a/anonyfiles_cli/config_validator.py
+++ b/anonyfiles_cli/config_validator.py
@@ -25,7 +25,10 @@ SCHEMA = {
             'schema': {'type': 'string'}
         },
         'default': []
-    }
+    },
+    'default_output_dir': {'type': 'string', 'required': False},
+    'backup_original': {'type': 'boolean', 'required': False},
+    'compression': {'type': 'boolean', 'required': False}
 }
 
 def validate_config(config_path: Path):

--- a/anonyfiles_cli/managers/validation_manager.py
+++ b/anonyfiles_cli/managers/validation_manager.py
@@ -33,7 +33,10 @@ SCHEMA = {
             'type': 'string'
         },
         'default': []
-    }
+    },
+    'default_output_dir': {'type': 'string', 'required': False},
+    'backup_original': {'type': 'boolean', 'required': False},
+    'compression': {'type': 'boolean', 'required': False}
 }
 
 

--- a/tests/unit/test_config_schema.py
+++ b/tests/unit/test_config_schema.py
@@ -1,0 +1,14 @@
+import pytest
+from anonyfiles_cli.managers.validation_manager import ValidationManager
+
+
+def test_validate_config_allows_extra_fields(tmp_path):
+    cfg = {
+        'spacy_model': 'fr_core_news_md',
+        'replacements': {},
+        'default_output_dir': '/tmp',
+        'backup_original': True,
+        'compression': False,
+    }
+    # Should not raise
+    ValidationManager.validate_config_dict(cfg)


### PR DESCRIPTION
## Summary
- extend validation schema in `validation_manager` and `config_validator`
- ensure config manager accepts `default_output_dir`, `backup_original` and `compression`
- add regression test for schema update

## Testing
- `pytest -k "not gui"`

------
https://chatgpt.com/codex/tasks/task_e_6849d973a778832384a3d8f17958e3b7