### PR TITLE
Add progress indicator for anonymization

### DIFF
--- a/anonyfiles_cli/README.md
+++ b/anonyfiles_cli/README.md
@@ -32,6 +32,7 @@ Il s’appuie sur le NLP (spaCy), une configuration flexible en YAML, et des rè
 * **Robustesse et performance** :
   + Chargement paresseux de spaCy, gestion fine des erreurs, cache en mémoire
   + Interface console enrichie (Rich)
+  + Indicateur de progression lors de l'anonymisation
 * **Gestion des jobs** :
   + Nettoyage et listage des fichiers de sortie des jobs pour une meilleure gestion de la confidentialité.
 

--- a/anonyfiles_cli/handlers/anonymize_handler.py
+++ b/anonyfiles_cli/handlers/anonymize_handler.py
@@ -116,15 +116,19 @@ class AnonymizeHandler:
             if input_file.suffix.lower() == ".csv" and csv_has_header_bool is not None:
                 processor_kwargs["has_header"] = csv_has_header_bool
 
-            result = engine.anonymize(
-                input_path=input_file,
-                output_path=paths.get("output_file"),
-                entities=None,  # La gestion des entités exclues est dans AnonyfilesEngine
-                dry_run=dry_run,
-                log_entities_path=paths.get("log_entities_file"),
-                mapping_output_path=paths.get("mapping_file"),
-                **processor_kwargs,
-            )
+            with self.console.console.status(
+                "[bold green]🔄 Anonymisation en cours...[/bold green]",
+                spinner="dots",
+            ):
+                result = engine.anonymize(
+                    input_path=input_file,
+                    output_path=paths.get("output_file"),
+                    entities=None,  # La gestion des entités exclues est dans AnonyfilesEngine
+                    dry_run=dry_run,
+                    log_entities_path=paths.get("log_entities_file"),
+                    mapping_output_path=paths.get("mapping_file"),
+                    **processor_kwargs,
+                )
 
             if result.get("status") == "error":
                 raise ProcessingError(result.get("error", "Le moteur d'anonymisation a signalé une erreur."))


### PR DESCRIPTION
## Summary
- show a Rich spinner while `engine.anonymize` runs
- document progress indicator in CLI README

## Testing
- `pytest tests/cli tests/unit -q`

------
https://chatgpt.com/codex/tasks/task_e_6849e330acac83239c18a5e0e63ed0fc