### PR TITLE
Add shell completion docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ pip install -r anonyfiles_api/requirements.txt
 
 ➡️ Voir [`anonyfiles_cli/README.md`](anonyfiles_cli/README.md)
 
+Pour activer l'autocomplétion Bash, Zsh ou Fish :
+
+```bash
+anonyfiles_cli --install-completion bash   # ou zsh/fish
+```
+
 ![Aperçu de la CLI](https://i.imgur.com/GJksQfm.jpeg)
 
 ### Installation GUI

--- a/anonyfiles_cli/README.md
+++ b/anonyfiles_cli/README.md
@@ -145,6 +145,22 @@ python -m anonyfiles_cli.main anonymize anonyfiles_cli/input.txt --interactive
 
 La CLI affichera la liste des labels (PER, ORG, LOC, EMAIL, DATE, ...) et générera automatiquement l'argument `--exclude-entities` selon vos choix.
 
+### **⚙️ Installation des complétions**
+
+Pour activer l'autocomplétion de la CLI, exécutez :
+
+```bash
+anonyfiles_cli --install-completion bash   # pour Bash
+anonyfiles_cli --install-completion zsh    # pour Zsh
+anonyfiles_cli --install-completion fish   # pour Fish
+```
+
+Vous pouvez aussi obtenir le script directement :
+
+```bash
+anonyfiles_cli completion bash
+```
+
 
 ## **🧹 Gestion des jobs (nettoyage et listage)**
 

--- a/anonyfiles_cli/commands/utils.py
+++ b/anonyfiles_cli/commands/utils.py
@@ -154,3 +154,18 @@ def run_benchmark(
         console.console.print(f"⏱️ Temps moyen : [cyan]{avg_time:.2f}s[/cyan]")
         console.console.print(f"🚀 Plus rapide : [green]{min_time:.2f}s[/green]")
         console.console.print(f"🐌 Plus lent : [red]{max_time:.2f}s[/red]")
+
+
+@app.command(name="completion", help="Affiche le script d'autocompl\xe9tion pour un shell.")
+def generate_completion(
+    shell: str = typer.Argument(..., help="Type de shell : bash, zsh ou fish")
+):
+    """Imprime le script d'autocompl\xe9tion pour le shell donn\xe9."""
+    from typer._completion_shared import get_completion_script
+
+    script = get_completion_script(
+        prog_name="anonyfiles_cli",
+        complete_var="_ANONYFILES_CLI_COMPLETE",
+        shell=shell,
+    )
+    typer.echo(script)


### PR DESCRIPTION
## Summary
- document CLI autocompletion in README files
- add a `completion` command to print completion scripts

## Testing
- `pip install -r requirements-test.txt`
- `pytest -k "not gui"` *(fails: ModuleNotFoundError: No module named 'pythonjsonlogger')*

------
https://chatgpt.com/codex/tasks/task_e_6849e7213ca48323973d658cd894f16e