### PR TITLE
Improve API router documentation

### DIFF
--- a/anonyfiles_api/routers/deanonymization.py
+++ b/anonyfiles_api/routers/deanonymization.py
@@ -48,7 +48,15 @@ def run_deanonymization_job_sync(
     permissive: bool,
     # Si BASE_CONFIG était nécessaire, il faudrait l'ajouter ici :
     # passed_base_config: Optional[Dict[str, Any]] = None
-):
+) -> None:
+    """Execute the deanonymization process for a given job.
+
+    Args:
+        job_id: Identifier for the job directory.
+        input_path: Path to the anonymized file to restore.
+        mapping_path: Path to the mapping CSV used for restoration.
+        permissive: Whether to continue when encountering mapping issues.
+    """
     set_job_id(job_id)
     current_job = Job(job_id)
     run_dir = current_job.job_dir
@@ -163,7 +171,19 @@ async def deanonymize_file_endpoint(
     file: UploadFile = File(...),
     mapping: UploadFile = File(...),
     permissive: bool = Form(False)
-): 
+):
+    """Upload files and trigger a deanonymization job.
+
+    Args:
+        request: Incoming request to access application state if needed.
+        background_tasks: FastAPI background task manager.
+        file: The anonymized file to restore.
+        mapping: Mapping CSV file.
+        permissive: Whether the engine should ignore missing mapping entries.
+
+    Returns:
+        A dictionary containing the created job ID and its initial status.
+    """
     job_id = str(uuid.uuid4())
     set_job_id(job_id)
     current_job = Job(job_id)
@@ -231,6 +251,15 @@ async def deanonymize_file_endpoint(
 
 @router.get("/deanonymize_status/{job_id}", tags=["Désanonymisation"])
 async def get_deanonymize_status(job_id: str):
+    """Return the status and results for a deanonymization job.
+
+    Args:
+        job_id: Identifier of the job to inspect.
+
+    Returns:
+        A JSON payload describing the job state and, if available, the restored
+        text and report.
+    """
     set_job_id(job_id)
     current_job = Job(job_id)
 

--- a/anonyfiles_api/routers/files.py
+++ b/anonyfiles_api/routers/files.py
@@ -18,6 +18,16 @@ router = APIRouter()
 
 @router.get("/files/{job_id}/{file_key}", tags=["Fichiers"])
 async def get_file_endpoint(job_id: uuid.UUID, file_key: str, as_attachment: bool = False):
+    """Serve a result file for a given job.
+
+    Args:
+        job_id: Identifier of the job directory.
+        file_key: Type of file to retrieve (output, mapping, log_entities, audit_log).
+        as_attachment: If ``True``, force download rather than inline display.
+
+    Returns:
+        A :class:`FileResponse` with the requested file.
+    """
     job_id_str = str(job_id)
     set_job_id(job_id_str)
     current_job = Job(job_id_str)

--- a/anonyfiles_api/routers/health.py
+++ b/anonyfiles_api/routers/health.py
@@ -4,4 +4,9 @@ router = APIRouter()
 
 @router.get("/health", tags=["Health"])
 async def health() -> dict:
+    """Simple health-check endpoint.
+
+    Returns:
+        ``{"status": "ok"}`` if the service is running.
+    """
     return {"status": "ok"}

--- a/anonyfiles_api/routers/jobs.py
+++ b/anonyfiles_api/routers/jobs.py
@@ -15,6 +15,14 @@ router = APIRouter()
 
 @router.delete("/jobs/{job_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["Tâches"])
 async def delete_job_endpoint(job_id: uuid.UUID): # job_id peut être str aussi
+    """Delete all files related to a job.
+
+    Args:
+        job_id: Identifier of the job directory to remove.
+
+    Returns:
+        An empty ``204 NO CONTENT`` response when successful.
+    """
     job_id_str = str(job_id)
     set_job_id(job_id_str)
     current_job = Job(job_id_str)

--- a/anonyfiles_api/routers/websocket_status.py
+++ b/anonyfiles_api/routers/websocket_status.py
@@ -10,7 +10,12 @@ router = APIRouter()
 
 @router.websocket("/ws/{job_id}")
 async def websocket_job_status(websocket: WebSocket, job_id: str) -> None:
-    """Envoie en temps réel le statut d'un job via WebSocket."""
+    """Send real-time job status updates over a WebSocket connection.
+
+    Args:
+        websocket: Active WebSocket connection to the client.
+        job_id: Identifier of the job to monitor.
+    """
     await websocket.accept()
     job = Job(job_id)
     if not await job.check_exists_async():


### PR DESCRIPTION
## Summary
- document engine option prep functions and job runners
- add docstrings to router endpoints for files, jobs, health and websocket status

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a02411f4c8323a078c9fddda3a2e2