### PR TITLE
Preserve typer.Exit in CLI commands

### DIFF
--- a/anonyfiles_cli/commands/anonymize.py
+++ b/anonyfiles_cli/commands/anonymize.py
@@ -85,6 +85,9 @@ def process_anonymize(
         console.handle_error(e, "anonymize_command_validation_or_setup")
         raise typer.Exit(code=ExitCodes.CONFIG_ERROR) # ou l'exit code approprié à l'erreur
 
+    except typer.Exit:
+        raise
+
     except Exception as e:
         console.handle_error(e, "anonymize_command_unexpected")
         raise typer.Exit(code=ExitCodes.GENERAL_ERROR)

--- a/anonyfiles_cli/commands/batch.py
+++ b/anonyfiles_cli/commands/batch.py
@@ -60,6 +60,9 @@ def process_batch(
         console.handle_error(e, "batch_command_setup")
         raise typer.Exit(code=e.exit_code) # Utilise l'exit_code défini dans AnonyfilesError
 
+    except typer.Exit:
+        raise
+
     except Exception as e:
         console.handle_error(e, "batch_command_unexpected")
         raise typer.Exit(code=ExitCodes.GENERAL_ERROR)

--- a/anonyfiles_cli/commands/clean_job.py
+++ b/anonyfiles_cli/commands/clean_job.py
@@ -62,6 +62,8 @@ def delete_job(
     except AnonyfilesError as e:
         console.handle_error(e, "delete_job_command")
         raise typer.Exit(e.exit_code)
+    except typer.Exit:
+        raise
     except Exception as e:
         console.handle_error(e, "delete_job_command_unexpected")
         raise typer.Exit(1)
@@ -107,6 +109,8 @@ def list_jobs(
     except AnonyfilesError as e:
         console.handle_error(e, "list_jobs_command")
         raise typer.Exit(e.exit_code)
+    except typer.Exit:
+        raise
     except Exception as e:
         console.handle_error(e, "list_jobs_command_unexpected")
         raise typer.Exit(1)

--- a/anonyfiles_cli/commands/config.py
+++ b/anonyfiles_cli/commands/config.py
@@ -44,6 +44,9 @@ def show_config(
                 console.console.print(f"\n[dim]Fichier de configuration utilisateur : {user_config_path}[/dim]")
             else:
                 console.console.print(f"\n[dim]Aucun fichier de configuration utilisateur trouvé. La configuration par défaut est utilisée.[/dim]")
+    except typer.Exit:
+        raise
+
     except Exception as e:
         console.handle_error(e, "config_show_command")
         raise typer.Exit(ExitCodes.GENERAL_ERROR)
@@ -64,6 +67,9 @@ def create_config(
     try:
         ConfigManager.create_default_user_config()
         console.console.print(f"✅ Configuration par défaut créée dans : [green]{user_config_path}[/green]")
+    except typer.Exit:
+        raise
+
     except Exception as e:
         console.handle_error(e, "config_create_command")
         raise typer.Exit(ExitCodes.CONFIG_ERROR)
@@ -87,6 +93,9 @@ def reset_config(
                 os.remove(user_config_path)
                 ConfigManager.create_default_user_config()  # Recrée une version par défaut
                 console.console.print("✅ Configuration utilisateur réinitialisée.")
+            except typer.Exit:
+                raise
+
             except Exception as e:
                 console.handle_error(e, "config_reset_command")
                 raise typer.Exit(ExitCodes.CONFIG_ERROR)
@@ -98,6 +107,9 @@ def reset_config(
         try:
             ConfigManager.create_default_user_config()
             console.console.print(f"✅ Configuration par défaut créée dans : [green]{user_config_path}[/green]")
+        except typer.Exit:
+            raise
+
         except Exception as e:
             console.handle_error(e, "config_reset_command")
             raise typer.Exit(ExitCodes.CONFIG_ERROR)
@@ -111,6 +123,9 @@ def edit_config():
         try:
             ConfigManager.create_default_user_config()
             console.console.print(f"✅ Fichier de configuration par défaut créé : [green]{user_config_path}[/green]", style="green")
+        except typer.Exit:
+            raise
+
         except Exception as e:
             console.handle_error(e, "config_edit_command")
             raise typer.Exit(ExitCodes.CONFIG_ERROR)
@@ -130,6 +145,8 @@ def validate_config_cmd(
     except ConfigurationError as e:
         console.console.print(f"❌ {e}", style="red")
         raise typer.Exit(ExitCodes.CONFIG_ERROR)
+    except typer.Exit:
+        raise
     except Exception as e:
         console.handle_error(e, "config_validate_command")
         raise typer.Exit(ExitCodes.GENERAL_ERROR)

--- a/anonyfiles_cli/commands/deanonymize.py
+++ b/anonyfiles_cli/commands/deanonymize.py
@@ -59,6 +59,9 @@ def process_deanonymize(
         console.handle_error(e, "deanonymize_command_validation_or_setup")
         raise typer.Exit(code=ExitCodes.CONFIG_ERROR)
 
+    except typer.Exit:
+        raise
+
     except Exception as e:
         console.handle_error(e, "deanonymize_command_unexpected")
         raise typer.Exit(code=ExitCodes.GENERAL_ERROR)

--- a/anonyfiles_cli/commands/utils.py
+++ b/anonyfiles_cli/commands/utils.py
@@ -80,6 +80,8 @@ def file_info(
         except Exception as e:
             console.console.print(f"❌ Erreur de lecture du contenu : {e}", style="red")
 
+    except typer.Exit:
+        raise
     except Exception as e:
         console.handle_error(e, "file_info_command")
         raise typer.Exit(code=ExitCodes.GENERAL_ERROR)
@@ -142,6 +144,8 @@ def run_benchmark(
             else:
                 console.console.print(f"  ❌ Erreur pendant l'itération, temps mesuré : {duration:.2f}s", style="red")
             
+        except typer.Exit:
+            raise
         except Exception as e:
             console.console.print(f"  ❌ Erreur inattendue lors du benchmark : [red]{e}[/red]", style="red")
     


### PR DESCRIPTION
## Summary
- avoid catching `typer.Exit` in CLI command modules
- insert dedicated `except typer.Exit: raise` blocks
- keep CLI tests passing

## Testing
- `env-cli/bin/pytest tests/cli -q`

------
https://chatgpt.com/codex/tasks/task_e_684a03e1767483239e1da90ba5babd64