### PR TITLE
Add CLI test for job list missing directory

### DIFF
--- a/tests/cli/test_job_cli.py
+++ b/tests/cli/test_job_cli.py
@@ -1,0 +1,27 @@
+import pytest
+pytest.importorskip("typer")
+from typer.testing import CliRunner
+import importlib
+import types
+import sys
+
+# Stub heavy dependencies used during CLI import with minimal attributes
+sys.modules.setdefault("spacy", types.ModuleType("spacy"))
+
+fake_docx = types.ModuleType("docx")
+fake_docx.Document = lambda *a, **k: None
+sys.modules.setdefault("docx", fake_docx)
+
+sys.modules.setdefault("pandas", types.ModuleType("pandas"))
+sys.modules.setdefault("fitz", types.ModuleType("fitz"))
+
+from anonyfiles_cli.main import app
+
+
+def test_job_list_nonexistent_directory(tmp_path):
+    output_dir = tmp_path / "does_not_exist"
+    runner = CliRunner()
+    result = runner.invoke(app, ["job", "list", "--output-dir", str(output_dir)])
+    assert result.exit_code == 0
+    assert "Le r\xe9pertoire des jobs" in result.output
+    assert "Traceback" not in result.output


### PR DESCRIPTION
## Summary
- add dedicated CLI test to ensure `job list` handles missing output directory gracefully

## Testing
- `pytest tests/cli/test_job_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684a05e053c4832392bd5ab16460d5c4