### PR TITLE
chore: passer à ruff 0.16 et adopter son jeu de règles

### DIFF
--- a/anonyfiles_api/api.py
+++ b/anonyfiles_api/api.py
@@ -4,32 +4,32 @@ import asyncio
 from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI, Request
-from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from slowapi import Limiter, _rate_limit_exceeded_handler
-from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
+from slowapi.util import get_remote_address
 
+from .auth import require_api_key
+from .core_config import (
+    DEFAULT_RATE_LIMIT,
+    JOBS_DIR,
+    AppConfig,
+    clear_request_context,
+    logger,
+    set_request_context,
+)
+from .job_queue import JobQueue
+from .retention import run_purge_loop
 from .routers import (
     anonymization,
     deanonymization,
     files,
-    jobs,
     health,
+    jobs,
     websocket_status,
 )
-from .core_config import (
-    logger,
-    JOBS_DIR,
-    DEFAULT_RATE_LIMIT,
-    set_request_context,
-    clear_request_context,
-    AppConfig,
-)
-from .job_queue import JobQueue
-from .retention import run_purge_loop
-from .auth import require_api_key
 
 # Plus besoin d'importer load_config_api_safe depuis anonyfiles_cli.main
 # CLI_MODULE_PATH = Path(__file__).resolve().parent.parent / "anonyfiles_cli"
@@ -86,7 +86,7 @@ async def _start_runtime(fastapi_app: FastAPI) -> None:
         )
         # On relève l'exception pour stopper Uvicorn (Fail Fast)
         await _stop_runtime(fastapi_app)
-        raise e
+        raise
 
 
 async def _stop_runtime(fastapi_app: FastAPI) -> None:
@@ -102,9 +102,9 @@ async def _stop_runtime(fastapi_app: FastAPI) -> None:
     if task is not None:
         try:
             await asyncio.wait_for(task, timeout=5)
-        except (asyncio.TimeoutError, asyncio.CancelledError):
+        except (TimeoutError, asyncio.CancelledError):
             task.cancel()
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.warning(f"Arrêt de la tâche de purge: {exc}")
 
 
@@ -194,12 +194,13 @@ async def read_root():
 
 
 if __name__ == "__main__":
-    import uvicorn
     import os
+
+    import uvicorn
 
     # SÉCURITÉ : Par défaut 127.0.0.1 (local uniquement).
     # Docker passera HOST=0.0.0.0 via les variables d'environnement.
     host = os.getenv("HOST", "127.0.0.1")
-    port = int(os.getenv("PORT", 8000))
+    port = int(os.getenv("PORT", "8000"))
 
     uvicorn.run(app, host=host, port=port)

--- a/anonyfiles_api/auth.py
+++ b/anonyfiles_api/auth.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterable
 from hmac import compare_digest
-from typing import Iterable
 
 from fastapi import HTTPException, Request, Security, status
 from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer

--- a/anonyfiles_api/core_config.py
+++ b/anonyfiles_api/core_config.py
@@ -2,11 +2,12 @@
 import logging
 import os
 import sys
-import yaml
-from pathlib import Path
 from contextvars import ContextVar
-from typing import Optional, Dict, Any
-from pydantic import Field, BaseModel, ConfigDict
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -22,11 +23,9 @@ logging.basicConfig(
 logger = logging.getLogger("anonyfiles_api")
 
 # ContextVar pour stocker l'ID du job courant
-_job_id_ctx: ContextVar[Optional[str]] = ContextVar("job_id", default=None)
-_request_context_path: ContextVar[Optional[str]] = ContextVar(
-    "request_path", default=None
-)
-_request_context_ip: ContextVar[Optional[str]] = ContextVar("request_ip", default=None)
+_job_id_ctx: ContextVar[str | None] = ContextVar("job_id", default=None)
+_request_context_path: ContextVar[str | None] = ContextVar("request_path", default=None)
+_request_context_ip: ContextVar[str | None] = ContextVar("request_ip", default=None)
 
 # --- Constantes ---
 CONFIG_TEMPLATE_PATH = (
@@ -71,15 +70,15 @@ DEFAULT_JOB_RETRY_ATTEMPTS = 0
 class ReplacementOptions(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    locale: Optional[str] = None
-    provider: Optional[str] = None
-    text: Optional[str] = None
+    locale: str | None = None
+    provider: str | None = None
+    text: str | None = None
     # Pour 'codes', pas d'options spécifiques requises mais on accepte des dicts génériques
 
 
 class EntityConfig(BaseModel):
     type: str  # ex: codes, faker, redact
-    options: Optional[ReplacementOptions] = Field(default_factory=ReplacementOptions)
+    options: ReplacementOptions | None = Field(default_factory=ReplacementOptions)
 
 
 class AnonymizationOptions(BaseModel):
@@ -114,7 +113,7 @@ class AppConfig(BaseSettings):
     )
 
     # Configuration des actions de remplacement pour chaque entité
-    replacements: Dict[str, EntityConfig] = Field(default_factory=dict)
+    replacements: dict[str, EntityConfig] = Field(default_factory=dict)
 
     # Autres configurations globales potentielles
     cors_origins: str = Field(
@@ -206,7 +205,7 @@ class YamlConfigSettingsSource(PydanticBaseSettingsSource):
         # Ici on simplifie en retournant tout le dictionnaire chargé.
         pass
 
-    def __call__(self) -> Dict[str, Any]:
+    def __call__(self) -> dict[str, Any]:
         if not self.yaml_file.is_file():
             logger.warning(
                 f"Fichier de configuration YAML non trouvé : {self.yaml_file}"
@@ -233,11 +232,11 @@ class YamlConfigSettingsSource(PydanticBaseSettingsSource):
 # --- Fonctions utilitaires contextuelles ---
 
 
-def set_job_id(job_id: Optional[str] = None) -> None:
+def set_job_id(job_id: str | None = None) -> None:
     _job_id_ctx.set(job_id)
 
 
-def get_job_id() -> Optional[str]:
+def get_job_id() -> str | None:
     return _job_id_ctx.get()
 
 

--- a/anonyfiles_api/job_queue.py
+++ b/anonyfiles_api/job_queue.py
@@ -1,10 +1,10 @@
 import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 from .core_config import logger
-from .job_utils import Job, TERMINAL_JOB_STATUSES, log_job_event, utc_now_iso
+from .job_utils import TERMINAL_JOB_STATUSES, Job, log_job_event, utc_now_iso
 
 
 @dataclass(slots=True)
@@ -13,7 +13,7 @@ class QueuedJob:
     kind: str
     func: Callable[..., None]
     kwargs: dict[str, Any]
-    timeout_seconds: Optional[float]
+    timeout_seconds: float | None
     retry_attempts: int
     retry_delay_seconds: float
     enqueued_at: str = field(default_factory=utc_now_iso)
@@ -33,7 +33,7 @@ class JobQueue:
         self,
         *,
         worker_count: int = 1,
-        timeout_seconds: Optional[float] = None,
+        timeout_seconds: float | None = None,
         retry_attempts: int = 0,
         retry_delay_seconds: float = 1.0,
     ) -> None:
@@ -75,7 +75,7 @@ class JobQueue:
                     asyncio.gather(*self._workers, return_exceptions=True),
                     timeout=timeout_seconds,
                 )
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 logger.warning(
                     "Arrêt de la file de jobs: timeout après %ss.", timeout_seconds
                 )
@@ -90,8 +90,8 @@ class JobQueue:
         kind: str,
         func: Callable[..., None],
         kwargs: dict[str, Any],
-        timeout_seconds: Optional[float] = None,
-        retry_attempts: Optional[int] = None,
+        timeout_seconds: float | None = None,
+        retry_attempts: int | None = None,
     ) -> None:
         if self._stopping:
             raise RuntimeError("La file de jobs est en cours d'arrêt.")
@@ -246,7 +246,7 @@ class JobQueue:
                 await asyncio.wait_for(runner, timeout=queued_job.timeout_seconds)
             else:
                 await runner
-        except asyncio.TimeoutError:
+        except TimeoutError:
             await job.update_status_async(
                 protect_terminal=False,
                 status="timeout",
@@ -262,7 +262,7 @@ class JobQueue:
             status_payload = await job.get_status_async() or {}
             self._log_job_finished(queued_job, status_payload)
             return False
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             await job.set_status_as_error_async(
                 f"Erreur inattendue dans la file de jobs: {exc}",
                 final_status_category="unexpected_error",

--- a/anonyfiles_api/job_utils.py
+++ b/anonyfiles_api/job_utils.py
@@ -1,18 +1,19 @@
 # anonyfiles/anonyfiles_api/job_utils.py
-from pathlib import Path
-import shutil
 import json
 import os
+import shutil
 import tempfile
 import threading
-from datetime import datetime, timezone
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
 import aiofiles
 import aiofiles.os as aio_os
 from fastapi.concurrency import run_in_threadpool
-from typing import Optional, Any, Dict
 
 from . import core_config
-from .core_config import logger, BASE_INPUT_STEM_FOR_JOB_FILES
+from .core_config import BASE_INPUT_STEM_FOR_JOB_FILES, logger
 
 JOBS_DIR = core_config.JOBS_DIR
 TERMINAL_JOB_STATUSES = {"finished", "error", "cancelled", "timeout"}
@@ -21,10 +22,10 @@ _STATUS_WRITE_LOCK = threading.RLock()
 
 
 def utc_now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(UTC).isoformat()
 
 
-def _parse_iso_datetime(value: Any) -> Optional[datetime]:
+def _parse_iso_datetime(value: Any) -> datetime | None:
     if not isinstance(value, str) or not value:
         return None
     try:
@@ -32,11 +33,11 @@ def _parse_iso_datetime(value: Any) -> Optional[datetime]:
     except ValueError:
         return None
     if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
+        return parsed.replace(tzinfo=UTC)
     return parsed
 
 
-def _duration_seconds(start_value: Any, end_value: Any) -> Optional[float]:
+def _duration_seconds(start_value: Any, end_value: Any) -> float | None:
     start = _parse_iso_datetime(start_value)
     end = _parse_iso_datetime(end_value)
     if start is None or end is None:
@@ -44,7 +45,7 @@ def _duration_seconds(start_value: Any, end_value: Any) -> Optional[float]:
     return round(max(0.0, (end - start).total_seconds()), 3)
 
 
-def _default_final_status_category(status: Optional[str]) -> Optional[str]:
+def _default_final_status_category(status: str | None) -> str | None:
     if status == "finished":
         return "success"
     if status == "cancelled":
@@ -77,7 +78,7 @@ class Job:
         self.audit_log_file_path = self.job_dir / "audit_log.json"
         self.base_input_stem = BASE_INPUT_STEM_FOR_JOB_FILES
 
-    def _read_status_sync(self) -> Dict[str, Any]:
+    def _read_status_sync(self) -> dict[str, Any]:
         if not self.status_file_path.is_file():
             return {}
         try:
@@ -88,11 +89,11 @@ class Job:
             return {}
 
     def _write_status_payload_sync(
-        self, payload: Dict[str, Any], updated_at: Optional[str] = None
+        self, payload: dict[str, Any], updated_at: str | None = None
     ) -> None:
         self.job_dir.mkdir(parents=True, exist_ok=True)
         payload["updated_at"] = updated_at or utc_now_iso()
-        tmp_path: Optional[str] = None
+        tmp_path: str | None = None
         try:
             with tempfile.NamedTemporaryFile(
                 "w",
@@ -211,7 +212,7 @@ class Job:
             return await run_in_threadpool(self.status_file_path.exists)
         return True
 
-    async def get_status_async(self) -> Optional[Dict[str, Any]]:
+    async def get_status_async(self) -> dict[str, Any] | None:
         if not await run_in_threadpool(self.status_file_path.is_file):
             logger.warning(
                 f"Tâche {self.job_id}: status.json non trouvé pour lecture du statut."
@@ -241,7 +242,7 @@ class Job:
             )
             return None
 
-    def _find_latest_file_sync(self, glob_suffix_pattern: str) -> Optional[Path]:
+    def _find_latest_file_sync(self, glob_suffix_pattern: str) -> Path | None:
         glob_pattern = f"{self.base_input_stem}{glob_suffix_pattern}"
         logger.debug(
             f"Tâche {self.job_id}: Recherche fichier {self.job_dir} motif: {glob_pattern}"
@@ -256,7 +257,7 @@ class Job:
             return candidates[0]
         return None
 
-    def get_file_path_sync(self, file_key: str) -> Optional[Path]:
+    def get_file_path_sync(self, file_key: str) -> Path | None:
         if file_key == "output":
             return self._find_latest_file_sync("_anonymise_*")
         elif file_key == "mapping":
@@ -269,7 +270,7 @@ class Job:
         logger.warning(f"Tâche {self.job_id}: Clé de fichier inconnue '{file_key}'.")
         return None
 
-    async def read_file_content_async(self, file_path: Path) -> Optional[str]:
+    async def read_file_content_async(self, file_path: Path) -> str | None:
         if not await run_in_threadpool(file_path.is_file):
             logger.warning(
                 f"Tâche {self.job_id}: Tentative de lecture d'un fichier inexistant: {file_path}"
@@ -340,7 +341,7 @@ class Job:
             return True
         return False
 
-    def set_status_as_finished_sync(self, engine_result: Dict[str, Any]) -> bool:
+    def set_status_as_finished_sync(self, engine_result: dict[str, Any]) -> bool:
         try:
             if not self.update_status_sync(
                 status="finished",
@@ -373,11 +374,11 @@ class Job:
             )
             # Try to report the error
             self.set_status_as_error_sync(
-                f"Erreur critique: Échec de l'écriture du statut 'finished'/journal d'audit après l'exécution réussie du moteur: {str(e)}"
+                f"Erreur critique: Échec de l'écriture du statut 'finished'/journal d'audit après l'exécution réussie du moteur: {e!s}"
             )
             return False
 
-    async def set_status_as_finished_async(self, engine_result: Dict[str, Any]) -> bool:
+    async def set_status_as_finished_async(self, engine_result: dict[str, Any]) -> bool:
         return await run_in_threadpool(self.set_status_as_finished_sync, engine_result)
 
     def delete_job_directory_sync(self) -> bool:

--- a/anonyfiles_api/retention.py
+++ b/anonyfiles_api/retention.py
@@ -19,7 +19,6 @@ import logging
 import shutil
 import time
 from pathlib import Path
-from typing import List, Optional
 
 logger = logging.getLogger("anonyfiles_api.retention")
 
@@ -27,8 +26,8 @@ logger = logging.getLogger("anonyfiles_api.retention")
 def purge_expired_jobs(
     jobs_dir: Path,
     max_age_seconds: float,
-    now: Optional[float] = None,
-) -> List[str]:
+    now: float | None = None,
+) -> list[str]:
     """Supprime les répertoires de jobs plus vieux que ``max_age_seconds``.
 
     Args:
@@ -47,7 +46,7 @@ def purge_expired_jobs(
         return []
 
     reference = time.time() if now is None else now
-    deleted: List[str] = []
+    deleted: list[str] = []
 
     for entry in sorted(jobs_dir.iterdir()):
         if not entry.is_dir():
@@ -99,9 +98,9 @@ async def run_purge_loop(
     while not stop_event.is_set():
         try:
             await asyncio.to_thread(purge_expired_jobs, jobs_dir, max_age_seconds)
-        except Exception as exc:  # noqa: BLE001 - la boucle ne doit jamais mourir
+        except Exception as exc:
             logger.error("Rétention: erreur inattendue pendant la purge (%s).", exc)
         try:
             await asyncio.wait_for(stop_event.wait(), timeout=interval_seconds)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             continue

--- a/anonyfiles_api/routers/anonymization.py
+++ b/anonyfiles_api/routers/anonymization.py
@@ -1,45 +1,45 @@
 # anonyfiles/anonyfiles_api/routers/anonymization.py
 
+import json
+import uuid
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+import aiofiles.os as aio_os
 from fastapi import (
     APIRouter,
-    UploadFile,
     File,
     Form,
     HTTPException,
     Request,
+    UploadFile,
 )
-from fastapi.responses import JSONResponse
 from fastapi.concurrency import run_in_threadpool
-from typing import Optional, Any, Dict
-from pathlib import Path
-from tempfile import TemporaryDirectory
-import json
-import uuid
-import aiofiles.os as aio_os
-
+from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 
-from ..core_config import logger, set_job_id, AnonymizationOptions
-from ..job_queue import ensure_job_queue
-from ..job_utils import Job, BASE_INPUT_STEM_FOR_JOB_FILES
-from ..upload_utils import (
-    UploadTooLargeError,
-    safe_upload_filename,
-    stream_upload_to_path,
-)
-
-from anonyfiles_core.anonymizer.run_logger import log_run_event
+from anonyfiles_cli.cli_logger import CLIUsageLogger
+from anonyfiles_core import AnonyfilesEngine
 from anonyfiles_core.anonymizer.engine_options import (
     build_exclude_entities,
     build_processor_kwargs,
     parse_custom_replacement_rules,
 )
-from anonyfiles_cli.cli_logger import CLIUsageLogger
-from anonyfiles_core import AnonyfilesEngine
 from anonyfiles_core.anonymizer.file_utils import (
-    default_output,
-    default_mapping,
     default_log,
+    default_mapping,
+    default_output,
+)
+from anonyfiles_core.anonymizer.run_logger import log_run_event
+
+from ..core_config import AnonymizationOptions, logger, set_job_id
+from ..job_queue import ensure_job_queue
+from ..job_utils import BASE_INPUT_STEM_FOR_JOB_FILES, Job
+from ..upload_utils import (
+    UploadTooLargeError,
+    safe_upload_filename,
+    stream_upload_to_path,
 )
 
 router = APIRouter()
@@ -59,8 +59,8 @@ ALLOWED_ENTITY_DECISION_SOURCES = {"detected", "manual"}
 
 
 def _prepare_engine_options(
-    config_options: dict, custom_rules: Optional[list]
-) -> Dict[str, Any]:
+    config_options: dict, custom_rules: list | None
+) -> dict[str, Any]:
     """Create options for :class:`AnonyfilesEngine` from the request payload."""
     exclude_entities = build_exclude_entities(
         config_options, has_custom_rules=bool(custom_rules)
@@ -75,13 +75,13 @@ def _prepare_engine_options(
 
 
 def _prepare_processor_kwargs(
-    input_path: Path, has_header: Optional[bool]
-) -> Dict[str, Any]:
+    input_path: Path, has_header: bool | None
+) -> dict[str, Any]:
     """Build keyword arguments for the engine processor."""
     return build_processor_kwargs(input_path, has_header=has_header)
 
 
-def _parse_entity_decisions(entity_decisions: Optional[str]) -> list[dict[str, Any]]:
+def _parse_entity_decisions(entity_decisions: str | None) -> list[dict[str, Any]]:
     """Parse preview decisions sent by the GUI before final anonymization."""
     if not entity_decisions or not entity_decisions.strip():
         return []
@@ -146,7 +146,7 @@ def _engine_entity_decision_options(
 
 
 def _preview_entities_from_engine_result(
-    engine_result: Dict[str, Any],
+    engine_result: dict[str, Any],
 ) -> list[dict[str, Any]]:
     audit_counts: dict[tuple[str, str], int] = {}
     for entry in engine_result.get("audit_log", []):
@@ -184,7 +184,7 @@ def _execute_engine_anonymization(
     log_entities_path: Path,
     mapping_output_path: Path,
     processor_kwargs: dict,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Run the anonymization engine synchronously."""
     logger.info(
         f"Tâche {input_path.parent.name}: Exécution du moteur AnonyfilesEngine."
@@ -207,7 +207,7 @@ async def _execute_engine_anonymization_async(
     log_entities_path: Path,
     mapping_output_path: Path,
     processor_kwargs: dict,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Run the anonymization engine asynchronously."""
     logger.info(
         f"Tâche {input_path.parent.name}: Exécution du moteur AnonyfilesEngine (async)."
@@ -225,7 +225,7 @@ async def _execute_engine_anonymization_async(
 
 def _process_engine_result(
     current_job: Job,
-    engine_result: Dict[str, Any],
+    engine_result: dict[str, Any],
     input_path: Path,
     output_path: Path,
     mapping_output_path: Path,
@@ -246,7 +246,7 @@ def _process_engine_result(
     engine_error_message = engine_result.get("error")
 
     final_status_for_log_event: str
-    final_error_for_log_event: Optional[str] = None
+    final_error_for_log_event: str | None = None
 
     if engine_status_reported == "success":
         write_ok = current_job.set_status_as_finished_sync(engine_result)
@@ -288,9 +288,9 @@ def _handle_job_error(
     e: Exception,
     error_context: str,
     input_path: Path,
-    output_path: Optional[Path] = None,
-    mapping_output_path: Optional[Path] = None,
-    log_entities_path: Optional[Path] = None,
+    output_path: Path | None = None,
+    mapping_output_path: Path | None = None,
+    log_entities_path: Path | None = None,
 ) -> None:
     """Log an error and update the job status accordingly.
 
@@ -304,14 +304,14 @@ def _handle_job_error(
         log_entities_path: Optional path to the entity log file.
     """
 
-    logger.error(f"Tâche {current_job.job_id}: {error_context} - {e}", exc_info=True)
+    logger.error("Tâche %s: %s - %s", current_job.job_id, error_context, e)
 
     if isinstance(e, FileNotFoundError):
         error_message = f"Fichier non trouvé: {getattr(e, 'filename', 'N/A')}"
     elif isinstance(e, PermissionError):
         error_message = f"Erreur de permission: {getattr(e, 'strerror', 'N/A')} sur {getattr(e, 'filename', 'N/A')}"
     else:
-        error_message = f"Erreur inattendue pendant {error_context}: {str(e)}"
+        error_message = f"Erreur inattendue pendant {error_context}: {e!s}"
 
     current_job.set_status_as_error_sync(
         error_message, final_status_category="unexpected_error"
@@ -342,10 +342,10 @@ def run_anonymization_job_sync(
     job_id: str,
     input_path: Path,
     config_options: dict,
-    has_header: Optional[bool],
-    custom_rules: Optional[list],
-    entity_decisions: Optional[list[dict[str, Any]]],
-    passed_base_config: Dict[str, Any],
+    has_header: bool | None,
+    custom_rules: list | None,
+    entity_decisions: list[dict[str, Any]] | None,
+    passed_base_config: dict[str, Any],
 ):
     """Execute an anonymization job in a background thread.
 
@@ -360,9 +360,9 @@ def run_anonymization_job_sync(
 
     set_job_id(job_id)
     current_job = Job(job_id)
-    output_path: Optional[Path] = None
-    mapping_output_path: Optional[Path] = None
-    log_entities_path: Optional[Path] = None
+    output_path: Path | None = None
+    mapping_output_path: Path | None = None
+    log_entities_path: Path | None = None
 
     if passed_base_config is None or not passed_base_config:
         logger.error(
@@ -481,9 +481,9 @@ async def anonymize_preview_endpoint(
     request: Request,
     file: UploadFile = File(...),
     config_options: str = Form(...),
-    custom_replacement_rules: Optional[str] = Form(None),
-    file_type: Optional[str] = Form(None),
-    has_header: Optional[str] = Form(None),
+    custom_replacement_rules: str | None = Form(None),
+    file_type: str | None = Form(None),
+    has_header: str | None = Form(None),
 ):
     """Preview detected entities without creating a job or writing output files."""
     logger.info(
@@ -495,7 +495,7 @@ async def anonymize_preview_endpoint(
     except json.JSONDecodeError as exc:
         raise HTTPException(
             status_code=400,
-            detail=f"JSON invalide pour config_options: {str(exc)}",
+            detail=f"JSON invalide pour config_options: {exc!s}",
         ) from exc
 
     if not isinstance(config_opts_raw, dict):
@@ -519,7 +519,7 @@ async def anonymize_preview_endpoint(
     except ValueError:
         custom_rules_list = []
 
-    has_header_bool: Optional[bool] = None
+    has_header_bool: bool | None = None
     if has_header is not None:
         has_header_bool = has_header.lower() in (
             "1",
@@ -537,7 +537,7 @@ async def anonymize_preview_endpoint(
             detail="Erreur serveur: Configuration de base non disponible pour prévisualiser la requête.",
         )
 
-    max_upload_bytes: Optional[int] = None
+    max_upload_bytes: int | None = None
     settings = getattr(request.app.state, "settings", None)
     if settings is not None and getattr(settings, "max_upload_size_mb", None):
         max_upload_bytes = int(settings.max_upload_size_mb) * 1024 * 1024
@@ -576,7 +576,7 @@ async def anonymize_preview_endpoint(
             detail=f"Fichier trop volumineux (limite: {exc.max_bytes} octets).",
         ) from exc
     except OSError as exc:
-        logger.error(f"Erreur de prévisualisation upload: {exc}", exc_info=True)
+        logger.exception("Erreur de prévisualisation upload")
         raise HTTPException(
             status_code=500,
             detail="Impossible de sauvegarder temporairement le fichier à prévisualiser.",
@@ -607,10 +607,10 @@ async def anonymize_file_endpoint(
     config_options: str = Form(...),
     # MODIFICATION CLÉ ICI :
     # Conserver Form(None) pour l'API, mais ajouter plus de robustesse au parsing JSON.
-    custom_replacement_rules: Optional[str] = Form(None),
-    entity_decisions: Optional[str] = Form(None),
-    file_type: Optional[str] = Form(None),
-    has_header: Optional[str] = Form(None),
+    custom_replacement_rules: str | None = Form(None),
+    entity_decisions: str | None = Form(None),
+    file_type: str | None = Form(None),
+    has_header: str | None = Form(None),
 ):
     """Handle file upload and start an anonymization job.
 
@@ -645,7 +645,7 @@ async def anonymize_file_endpoint(
     input_filename_for_job = f"{BASE_INPUT_STEM_FOR_JOB_FILES}{file_extension}"
     input_path_for_job = current_job.job_dir / input_filename_for_job
 
-    max_upload_bytes: Optional[int] = None
+    max_upload_bytes: int | None = None
     settings = getattr(request.app.state, "settings", None)
     if settings is not None and getattr(settings, "max_upload_size_mb", None):
         max_upload_bytes = int(settings.max_upload_size_mb) * 1024 * 1024
@@ -671,12 +671,11 @@ async def anonymize_file_endpoint(
             detail=f"Fichier trop volumineux (limite: {e_size.max_bytes} octets).",
         )
     except OSError as e_upload:
-        logger.error(
-            f"Tâche {job_id}: Erreur de téléversement '{input_filename_for_job}': {e_upload}",
-            exc_info=True,
+        logger.exception(
+            f"Tâche {job_id}: Erreur de téléversement '{input_filename_for_job}'",
         )
         await current_job.set_status_as_error_async(
-            f"Échec de la sauvegarde du fichier téléversé: {str(e_upload)}"
+            f"Échec de la sauvegarde du fichier téléversé: {e_upload!s}"
         )
         raise HTTPException(
             status_code=500,
@@ -701,8 +700,8 @@ async def anonymize_file_endpoint(
     try:
         config_opts_raw = json.loads(config_options)
     except json.JSONDecodeError as e_json_conf:
-        error_msg = f"JSON invalide pour config_options: {str(e_json_conf)}"
-        logger.error(f"Tâche {job_id}: {error_msg}", exc_info=True)
+        error_msg = f"JSON invalide pour config_options: {e_json_conf!s}"
+        logger.exception(f"Tâche {job_id}: {error_msg}")
         await current_job.set_status_as_error_async(
             error_msg + " Échec du parsing des options de configuration."
         )
@@ -751,7 +750,7 @@ async def anonymize_file_endpoint(
         await current_job.set_status_as_error_async(error_msg)
         raise HTTPException(status_code=400, detail=error_msg)
 
-    has_header_bool: Optional[bool] = None
+    has_header_bool: bool | None = None
     if has_header is not None:
         has_header_bool = has_header.lower() in (
             "1",
@@ -842,7 +841,7 @@ async def anonymize_status_endpoint(job_id: uuid.UUID):
         return JSONResponse(content=current_status)
 
     if current_status.get("status") == "finished":
-        response_payload: Dict[str, Any] = {**current_status, "status": "finished"}
+        response_payload: dict[str, Any] = {**current_status, "status": "finished"}
         if "error" in current_status and current_status["error"] is not None:
             response_payload["error"] = current_status["error"]
 
@@ -851,7 +850,7 @@ async def anonymize_status_endpoint(job_id: uuid.UUID):
         response_payload["log_csv"] = ""
         response_payload["audit_log"] = []
 
-        error_details: Dict[str, str] = {}
+        error_details: dict[str, str] = {}
 
         try:
             output_file_path = await run_in_threadpool(
@@ -866,10 +865,9 @@ async def anonymize_status_endpoint(job_id: uuid.UUID):
             audit_log_file_path = await run_in_threadpool(
                 current_job.get_file_path_sync, "audit_log"
             )
-        except Exception as e_find:
-            logger.error(
-                f"Tâche {job_id_str}: Erreur d'obtention des chemins de fichiers: {e_find}",
-                exc_info=True,
+        except Exception:
+            logger.exception(
+                f"Tâche {job_id_str}: Erreur d'obtention des chemins de fichiers",
             )
             response_payload["status"] = "error"
             response_payload["error"] = (

--- a/anonyfiles_api/routers/deanonymization.py
+++ b/anonyfiles_api/routers/deanonymization.py
@@ -1,20 +1,34 @@
 # anonyfiles/anonyfiles_api/routers/deanonymization.py
 
+import json
+import uuid
+from pathlib import Path
+
+import aiofiles
 from fastapi import (
     APIRouter,
-    UploadFile,
     File,
     Form,
     HTTPException,
     Request,
+    UploadFile,
 )  # Ajout de Request
-from fastapi.responses import JSONResponse
 from fastapi.concurrency import run_in_threadpool
-from pathlib import Path
-import aiofiles
-import uuid
-import json
-from typing import Optional  # Ajouté pour la cohérence du typage
+from fastapi.responses import JSONResponse
+
+from anonyfiles_cli.cli_logger import CLIUsageLogger  # Utilisé pour log_run_event
+from anonyfiles_core import DeanonymizationEngine
+from anonyfiles_core.anonymizer.file_utils import (
+    timestamp,
+)
+from anonyfiles_core.anonymizer.run_logger import log_run_event
+
+# MODIFICATION ICI: Importer SEULEMENT logger depuis core_config.
+# BASE_CONFIG n'est plus défini globalement dans core_config.py.
+# Si la logique de désanonymisation avait besoin de BASE_CONFIG, il faudrait le passer en argument
+# aux fonctions concernées, récupéré depuis request.app.state.BASE_CONFIG dans l'endpoint.
+# Pour l'instant, nous supposons que la désanonymisation n'a pas besoin de BASE_CONFIG.
+from ..core_config import BASE_INPUT_STEM_FOR_JOB_FILES, logger, set_job_id
 
 # Importer Job depuis job_utils (JOBS_DIR est géré à l'intérieur de Job ou core_config)
 from ..job_queue import ensure_job_queue
@@ -24,20 +38,6 @@ from ..upload_utils import (
     safe_upload_filename,
     stream_upload_to_path,
 )
-
-# MODIFICATION ICI: Importer SEULEMENT logger depuis core_config.
-# BASE_CONFIG n'est plus défini globalement dans core_config.py.
-# Si la logique de désanonymisation avait besoin de BASE_CONFIG, il faudrait le passer en argument
-# aux fonctions concernées, récupéré depuis request.app.state.BASE_CONFIG dans l'endpoint.
-# Pour l'instant, nous supposons que la désanonymisation n'a pas besoin de BASE_CONFIG.
-from ..core_config import logger, set_job_id, BASE_INPUT_STEM_FOR_JOB_FILES
-
-from anonyfiles_core import DeanonymizationEngine
-from anonyfiles_core.anonymizer.file_utils import (
-    timestamp,
-)
-from anonyfiles_core.anonymizer.run_logger import log_run_event
-from anonyfiles_cli.cli_logger import CLIUsageLogger  # Utilisé pour log_run_event
 
 router = APIRouter()
 
@@ -125,10 +125,7 @@ def run_deanonymization_job_sync(
         output_path = run_dir / output_filename
         report_file_path = run_dir / "report.json"
 
-        if (
-            "map_collisions_details" in report_data_serializable
-            and report_data_serializable["map_collisions_details"]
-        ):
+        if report_data_serializable.get("map_collisions_details"):
             report_data_serializable["map_collisions_details"] = {
                 code: list(originals)
                 for code, originals in report_data_serializable[
@@ -197,9 +194,8 @@ def run_deanonymization_job_sync(
 
     except Exception as e:
         error_msg = str(e)
-        logger.error(
+        logger.exception(
             f"[{job_id}] Erreur de désanonymisation pour {input_path.name} : {error_msg}",
-            exc_info=True,
         )
         # Mettre à jour le statut avec original_input_name
         error_payload_for_status = {
@@ -278,7 +274,7 @@ async def deanonymize_file_endpoint(
     input_path = job_dir / input_filename
     mapping_path = job_dir / mapping_filename
 
-    max_upload_bytes: Optional[int] = None
+    max_upload_bytes: int | None = None
     settings = getattr(request.app.state, "settings", None)
     if settings is not None and getattr(settings, "max_upload_size_mb", None):
         max_upload_bytes = int(settings.max_upload_size_mb) * 1024 * 1024
@@ -312,10 +308,9 @@ async def deanonymize_file_endpoint(
             status_code=413,
             detail=f"Fichier trop volumineux (limite: {e_size.max_bytes} octets).",
         )
-    except OSError as e_save_input:
-        logger.error(
-            f"Tâche {job_id}: Échec de la sauvegarde du fichier d'entrée '{input_filename}': {e_save_input}",
-            exc_info=True,
+    except OSError:
+        logger.exception(
+            f"Tâche {job_id}: Échec de la sauvegarde du fichier d'entrée '{input_filename}'",
         )
         _write_error_status(
             f"Impossible de sauvegarder le fichier d'entrée: {input_filename}"
@@ -346,10 +341,9 @@ async def deanonymize_file_endpoint(
             status_code=413,
             detail=f"Mapping trop volumineux (limite: {e_size.max_bytes} octets).",
         )
-    except OSError as e_save_mapping:
-        logger.error(
-            f"Tâche {job_id}: Échec de la sauvegarde du fichier de mapping '{mapping_filename}': {e_save_mapping}",
-            exc_info=True,
+    except OSError:
+        logger.exception(
+            f"Tâche {job_id}: Échec de la sauvegarde du fichier de mapping '{mapping_filename}'",
         )
         _write_error_status(
             f"Impossible de sauvegarder le fichier de mapping: {mapping_filename}"
@@ -451,7 +445,7 @@ async def get_deanonymize_status(job_id: str):
                 Path(original_input_name).stem or BASE_INPUT_STEM_FOR_JOB_FILES
             )
 
-            def _find_latest_with_original_prefix() -> Optional[Path]:
+            def _find_latest_with_original_prefix() -> Path | None:
                 pattern = f"{original_stem}_deanonymise_*{original_suffix}"
                 candidates = sorted(
                     (p for p in current_job.job_dir.glob(pattern) if p.is_file()),
@@ -498,14 +492,13 @@ async def get_deanonymize_status(job_id: str):
                 ),  # Peut y avoir une erreur même si statut "finished" (rare)
             }
         except Exception as e:
-            logger.error(
-                f"Erreur de récupération des fichiers pour la tâche de désanonymisation terminée {job_id}: {str(e)}",
-                exc_info=True,
+            logger.exception(
+                f"Erreur de récupération des fichiers pour la tâche de désanonymisation terminée {job_id}",
             )
             # Retourner le statut d'erreur si la récupération des fichiers échoue
             error_payload = {
                 "status": "error",
-                "error": f"Tâche terminée mais impossible de récupérer/traiter les fichiers de résultats: {str(e)}",
+                "error": f"Tâche terminée mais impossible de récupérer/traiter les fichiers de résultats: {e!s}",
                 "original_input_name": status_data.get(
                     "original_input_name", "unknown"
                 ),

--- a/anonyfiles_api/routers/files.py
+++ b/anonyfiles_api/routers/files.py
@@ -1,19 +1,17 @@
 # anonyfiles/anonyfiles_api/routers/files.py
 
-from fastapi import APIRouter, HTTPException
-from fastapi.responses import FileResponse
-from fastapi.concurrency import run_in_threadpool
-from pathlib import Path
-import uuid
 import mimetypes
+import uuid
+from pathlib import Path
 
 # import logging # Logger est maintenant importé depuis core_config
-from typing import Optional
-
-from ..job_utils import Job
+from fastapi import APIRouter, HTTPException
+from fastapi.concurrency import run_in_threadpool
+from fastapi.responses import FileResponse
 
 # Importer depuis le nouveau module de configuration central
 from ..core_config import logger, set_job_id  # Importer logger et set_job_id
+from ..job_utils import Job
 
 router = APIRouter()
 # 'logger' est maintenant importé de core_config et utilisé directement
@@ -54,15 +52,14 @@ async def get_file_endpoint(
             detail=f"Clé de fichier invalide. Valides: {', '.join(valid_file_keys)}",
         )
 
-    file_path_to_serve: Optional[Path] = None
+    file_path_to_serve: Path | None = None
     try:
         file_path_to_serve = await run_in_threadpool(
             current_job.get_file_path_sync, file_key
         )
-    except Exception as e_find:
-        logger.error(
-            f"Tâche {job_id_str}: Erreur de recherche du fichier clé '{file_key}': {e_find}",
-            exc_info=True,
+    except Exception:
+        logger.exception(
+            f"Tâche {job_id_str}: Erreur de recherche du fichier clé '{file_key}'",
         )
         raise HTTPException(
             status_code=500,

--- a/anonyfiles_api/routers/jobs.py
+++ b/anonyfiles_api/routers/jobs.py
@@ -1,16 +1,16 @@
 # anonyfiles/anonyfiles_api/routers/jobs.py
 
-from fastapi import APIRouter, HTTPException, Request, status, Response
-import aiofiles.os as aio_os
 import uuid
 
-# import logging # Logger est maintenant importé depuis core_config
-
-from ..job_utils import Job
-from ..job_queue import ensure_job_queue
+import aiofiles.os as aio_os
+from fastapi import APIRouter, HTTPException, Request, Response, status
 
 # Importer depuis le nouveau module de configuration central
 from ..core_config import logger, set_job_id  # Importer logger et context
+from ..job_queue import ensure_job_queue
+
+# import logging # Logger est maintenant importé depuis core_config
+from ..job_utils import Job
 
 router = APIRouter()
 # 'logger' est maintenant importé de core_config et utilisé directement

--- a/anonyfiles_api/routers/websocket_status.py
+++ b/anonyfiles_api/routers/websocket_status.py
@@ -1,11 +1,12 @@
 # anonyfiles/anonyfiles_api/routers/websocket_status.py
 
 import asyncio
+
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, status
 
 from ..auth import websocket_has_valid_api_key
-from ..job_utils import Job, TERMINAL_JOB_STATUSES
 from ..core_config import logger
+from ..job_utils import TERMINAL_JOB_STATUSES, Job
 
 router = APIRouter()
 

--- a/anonyfiles_api/upload_utils.py
+++ b/anonyfiles_api/upload_utils.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import os
 from pathlib import Path, PurePosixPath, PureWindowsPath
-from typing import Optional
 
 import aiofiles
 from fastapi import UploadFile
@@ -33,7 +32,7 @@ class UploadTooLargeError(Exception):
 
 
 def safe_upload_filename(
-    raw_filename: Optional[str],
+    raw_filename: str | None,
     *,
     fallback_stem: str = "upload",
     fallback_suffix: str = ".tmp",
@@ -76,7 +75,7 @@ async def stream_upload_to_path(
     upload_file: UploadFile,
     destination: Path,
     *,
-    max_bytes: Optional[int] = None,
+    max_bytes: int | None = None,
     chunk_size: int = DEFAULT_CHUNK_SIZE,
 ) -> int:
     """Stream ``upload_file`` to ``destination``, enforcing ``max_bytes``.

--- a/anonyfiles_cli/cli_logger.py
+++ b/anonyfiles_cli/cli_logger.py
@@ -1,12 +1,14 @@
 # anonyfiles_cli/cli_logger.py
 
+import contextlib
 import datetime
 import json
 import logging
-from typing import Any, Dict, Optional
-import typer
-from pathlib import Path
 import traceback
+from pathlib import Path
+from typing import Any
+
+import typer
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +21,7 @@ class CLIUsageLogger:
     VERBOSE: bool = False
 
     @classmethod
-    def get_log_path(cls) -> Optional[Path]:
+    def get_log_path(cls) -> Path | None:
         """Return the path to today's audit log file.
 
         The method creates the directory structure for the current date if
@@ -30,7 +32,7 @@ class CLIUsageLogger:
             Optional[Path]: Path object to ``cli_audit_log.jsonl``, or None if creation fails.
         """
         try:
-            now = datetime.datetime.now(datetime.timezone.utc)
+            now = datetime.datetime.now(datetime.UTC)
             log_dir = (
                 cls.LOG_BASE_DIR / str(now.year) / f"{now.month:02d}" / f"{now.day:02d}"
             )
@@ -54,7 +56,7 @@ class CLIUsageLogger:
             info (dict): Arbitrary metadata describing the executed command.
         """
         entry = {
-            "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
             **info,
         }
         log_path = cls.get_log_path()
@@ -74,12 +76,12 @@ class CLIUsageLogger:
         context: str,
         exc: Exception,
         *,
-        command: Optional[str] = None,
-        args: Optional[Dict[str, Any]] = None,
+        command: str | None = None,
+        args: dict[str, Any] | None = None,
     ):
         """Record an error entry in the audit log."""
-        entry: Dict[str, Any] = {
-            "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        entry: dict[str, Any] = {
+            "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
             "error": str(exc),
             "traceback": traceback.format_exc(),
             "context": context,
@@ -89,13 +91,11 @@ class CLIUsageLogger:
         if args is not None:
             entry["arguments"] = args
         elif cls.VERBOSE:
-            try:
+            with contextlib.suppress(Exception):
                 # Tentative de récupération du contexte Typer si disponible
                 ctx = typer.get_current_context()
                 entry["command"] = ctx.command_path
                 entry["arguments"] = ctx.params
-            except Exception:
-                pass
 
         log_path = cls.get_log_path()
         if not log_path:

--- a/anonyfiles_cli/commands/__init__.py
+++ b/anonyfiles_cli/commands/__init__.py
@@ -2,10 +2,12 @@
 
 # Importe les objets 'app' de chaque module de commande
 # Ces imports rendent les applications Typer disponibles pour le main.py
-from . import anonymize  # noqa: F401
-from . import deanonymize  # noqa: F401
-from . import config  # noqa: F401
-from . import batch  # noqa: F401
-from . import utils  # noqa: F401
-from . import clean_job  # noqa: F401
-from . import logs  # noqa: F401
+from . import (
+    anonymize,  # noqa: F401
+    batch,  # noqa: F401
+    clean_job,  # noqa: F401
+    config,  # noqa: F401
+    deanonymize,  # noqa: F401
+    logs,  # noqa: F401
+    utils,  # noqa: F401
+)

--- a/anonyfiles_cli/commands/anonymize.py
+++ b/anonyfiles_cli/commands/anonymize.py
@@ -1,16 +1,16 @@
 # anonyfiles_cli/commands/anonymize.py
 
-import typer
 from pathlib import Path
-from typing import Optional, List
 
+import typer
+
+from ..exceptions import (
+    AnonyfilesError,
+)  # Assurez-vous d'importer les exceptions nécessaires
 from ..handlers.anonymize_handler import AnonymizeHandler
 from ..handlers.validation_handler import ValidationHandler
 from ..ui.console_display import ConsoleDisplay
 from ..ui.interactive_mode import prompt_entities_to_exclude
-from ..exceptions import (
-    AnonyfilesError,
-)  # Assurez-vous d'importer les exceptions nécessaires
 
 app = typer.Typer(help="Commandes pour anonymiser les fichiers.")
 console = ConsoleDisplay()
@@ -37,7 +37,7 @@ def process_anonymize(
         dir_okay=False,
         readable=True,
     ),
-    config: Optional[Path] = typer.Option(
+    config: Path | None = typer.Option(
         None,
         "--config",
         "-c",
@@ -47,23 +47,23 @@ def process_anonymize(
         dir_okay=False,
         readable=True,
     ),
-    output: Optional[Path] = typer.Option(
+    output: Path | None = typer.Option(
         None,
         "--output",
         "-o",
         help="Chemin du fichier de sortie anonymisé (optionnel).",
     ),
-    log_entities: Optional[Path] = typer.Option(
+    log_entities: Path | None = typer.Option(
         None,
         "--log-entities",
         help="Chemin du fichier CSV de log des entités détectées (optionnel).",
     ),
-    mapping_output: Optional[Path] = typer.Option(
+    mapping_output: Path | None = typer.Option(
         None,
         "--mapping-output",
         help="Chemin du fichier CSV du mapping d'anonymisation (optionnel).",
     ),
-    bundle: Optional[Path] = typer.Option(
+    bundle: Path | None = typer.Option(
         None,
         "--bundle",
         "--output-bundle",
@@ -86,12 +86,12 @@ def process_anonymize(
         "--csv-no-header",
         help="Indique que le fichier CSV d'entrée N'A PAS d'en-tête (utilisé si --has-header-opt n'est pas fourni).",
     ),
-    has_header_opt: Optional[str] = typer.Option(
+    has_header_opt: str | None = typer.Option(
         None,
         "--has-header-opt",
         help="Spécifie explicitement si le fichier CSV d'entrée a une en-tête ('true'/'false'). Prioritaire sur --csv-no-header.",
     ),
-    exclude_entities: Optional[List[str]] = typer.Option(
+    exclude_entities: list[str] | None = typer.Option(
         None,
         "--exclude-entities",
         help="Types d'entités à exclure, séparés par des virgules (ex: PER,LOC).",
@@ -102,7 +102,7 @@ def process_anonymize(
         "-i",
         help="Sélection interactive des entités à anonymiser.",
     ),
-    custom_replacements_json: Optional[str] = typer.Option(
+    custom_replacements_json: str | None = typer.Option(
         None,
         "--custom-replacements-json",
         help='Chaîne JSON des règles de remplacement personnalisées (ex: \'[{"pattern": "Confidentiel", "replacement": "[SECRET]"}]\').',

--- a/anonyfiles_cli/commands/batch.py
+++ b/anonyfiles_cli/commands/batch.py
@@ -1,14 +1,14 @@
 # anonyfiles_cli/commands/batch.py
 
-import typer
 from pathlib import Path
-from typing import Optional
 
-from ..handlers.batch_handler import BatchHandler
-from ..ui.console_display import ConsoleDisplay
+import typer
+
 from ..exceptions import (
     AnonyfilesError,
 )  # Assurez-vous d'importer les exceptions nécessaires
+from ..handlers.batch_handler import BatchHandler
+from ..ui.console_display import ConsoleDisplay
 
 app = typer.Typer(help="Commandes pour le traitement de fichiers en lot.")
 console = ConsoleDisplay()
@@ -38,12 +38,12 @@ def process_batch(
     pattern: str = typer.Option(
         "*", "--pattern", help="Pattern de fichiers à inclure (ex: *.txt, *.csv)."
     ),
-    output_dir: Optional[Path] = typer.Option(
+    output_dir: Path | None = typer.Option(
         None,
         "--output-dir",
         help="Dossier où écrire les fichiers de sortie. Par défaut, un sous-dossier 'anonymized_output' dans le dossier d'entrée.",
     ),
-    config: Optional[Path] = typer.Option(
+    config: Path | None = typer.Option(
         None,
         "--config",
         "-c",
@@ -69,7 +69,7 @@ def process_batch(
         "--csv-no-header",
         help="Indique que les fichiers CSV d'entrée N'ONT PAS d'en-tête (s'applique à tous les CSV du lot).",
     ),
-    has_header_opt: Optional[str] = typer.Option(
+    has_header_opt: str | None = typer.Option(
         None,
         "--has-header-opt",
         help="Spécifie explicitement si les fichiers CSV d'entrée ont une en-tête ('true'/'false'). Prioritaire sur --csv-no-header pour le lot.",

--- a/anonyfiles_cli/commands/clean_job.py
+++ b/anonyfiles_cli/commands/clean_job.py
@@ -1,13 +1,15 @@
 # anonyfiles_cli/commands/clean_job.py
 
-import typer
-from pathlib import Path
 import shutil
+from pathlib import Path
+
+import typer
+
+from anonyfiles_cli.exceptions import AnonyfilesError
 
 # Importations des modules nécessaires
 from anonyfiles_cli.managers.config_manager import ConfigManager
 from anonyfiles_cli.ui.console_display import ConsoleDisplay
-from anonyfiles_cli.exceptions import AnonyfilesError
 from anonyfiles_cli.utils.default_paths import get_default_output_dir
 
 app = typer.Typer(help="Commandes pour gérer et nettoyer les jobs.")

--- a/anonyfiles_cli/commands/config.py
+++ b/anonyfiles_cli/commands/config.py
@@ -1,16 +1,16 @@
 # anonyfiles_cli/commands/config.py
 
-import typer
-from pathlib import Path
 import json
 import os
-from typing import Optional
+from pathlib import Path
 
+import typer
+
+from ..exceptions import ConfigurationError
 from ..managers.config_manager import ConfigManager
 from ..managers.validation_manager import ValidationManager
 from ..ui.console_display import ConsoleDisplay
 from ..utils.system_utils import open_file_in_editor  # Import de la fonction utilitaire
-from ..exceptions import ConfigurationError
 
 app = typer.Typer(help="Gère la configuration d'Anonyfiles.")
 console = ConsoleDisplay()
@@ -26,7 +26,7 @@ class ExitCodes:
 
 @app.command(name="show", help="Affiche la configuration effective actuelle.")
 def show_config(
-    key: Optional[str] = typer.Option(
+    key: str | None = typer.Option(
         None, "--key", help="Clé de configuration spécifique à afficher."
     ),
 ):

--- a/anonyfiles_cli/commands/deanonymize.py
+++ b/anonyfiles_cli/commands/deanonymize.py
@@ -1,15 +1,15 @@
 # anonyfiles_cli/commands/deanonymize.py
 
-import typer
 from pathlib import Path
-from typing import Optional
 
-from ..handlers.deanonymize_handler import DeanonymizeHandler
-from ..handlers.validation_handler import ValidationHandler
-from ..ui.console_display import ConsoleDisplay
+import typer
+
 from ..exceptions import (
     AnonyfilesError,
 )  # Assurez-vous d'importer les exceptions nécessaires
+from ..handlers.deanonymize_handler import DeanonymizeHandler
+from ..handlers.validation_handler import ValidationHandler
+from ..ui.console_display import ConsoleDisplay
 
 app = typer.Typer(help="Commandes pour désanonymiser les fichiers.")
 console = ConsoleDisplay()
@@ -44,10 +44,10 @@ def process_deanonymize(
         dir_okay=False,
         readable=True,
     ),
-    output: Optional[Path] = typer.Option(
+    output: Path | None = typer.Option(
         None, "--output", "-o", help="Fichier de sortie restauré (optionnel)."
     ),
-    report: Optional[Path] = typer.Option(
+    report: Path | None = typer.Option(
         None,
         "--report",
         help="Fichier de rapport détaillé JSON sur la désanonymisation (optionnel).",

--- a/anonyfiles_cli/commands/utils.py
+++ b/anonyfiles_cli/commands/utils.py
@@ -1,15 +1,15 @@
 # anonyfiles_cli/commands/utils.py
 
-import typer
 import json
-from pathlib import Path
-from typing import Optional
-from datetime import datetime
 import time
+from datetime import datetime
+from pathlib import Path
 
+import typer
+
+from ..managers.config_manager import ConfigManager
 from ..ui.console_display import ConsoleDisplay
 from ..utils.system_utils import detect_file_encoding  # Import de la fonction
-from ..managers.config_manager import ConfigManager
 
 app = typer.Typer(help="Commandes utilitaires pour Anonyfiles.")
 console = ConsoleDisplay()
@@ -62,7 +62,7 @@ def list_entities():
     help="Diagnostique spaCy et le modèle configuré.",
 )
 def spacy_status(
-    config: Optional[Path] = typer.Option(
+    config: Path | None = typer.Option(
         None,
         "--config",
         help="Fichier de configuration YAML à inspecter.",
@@ -71,7 +71,7 @@ def spacy_status(
         dir_okay=False,
         readable=True,
     ),
-    model: Optional[str] = typer.Option(
+    model: str | None = typer.Option(
         None,
         "--model",
         help="Modèle spaCy à diagnostiquer. Surcharge la configuration.",
@@ -203,7 +203,7 @@ def run_benchmark(
     iterations: int = typer.Option(
         3, "--iterations", "-i", help="Nombre d'itérations pour le benchmark."
     ),
-    config: Optional[Path] = typer.Option(
+    config: Path | None = typer.Option(
         None,
         "--config",
         help="Fichier de configuration YAML à tester pour le benchmark.",

--- a/anonyfiles_cli/config_validator.py
+++ b/anonyfiles_cli/config_validator.py
@@ -1,8 +1,9 @@
 # config_validator.py
 
+from pathlib import Path
+
 import yaml
 from cerberus import Validator
-from pathlib import Path
 
 SCHEMA = {
     "spacy_model": {"type": "string", "required": True},

--- a/anonyfiles_cli/handlers/anonymize_handler.py
+++ b/anonyfiles_cli/handlers/anonymize_handler.py
@@ -1,17 +1,13 @@
 # anonyfiles_cli/handlers/anonymize_handler.py
 
 from pathlib import Path
-from typing import Optional, List
 
 from anonyfiles_core import AnonyfilesEngine
-from anonyfiles_core.anonymizer.run_logger import log_run_event
 from anonyfiles_core.anonymizer.file_utils import (
     timestamp,
 )
-from ..managers.path_manager import PathManager
-from ..managers.config_manager import ConfigManager
-from ..managers.validation_manager import ValidationManager
-from ..ui.console_display import ConsoleDisplay
+from anonyfiles_core.anonymizer.run_logger import log_run_event
+
 from ..cli_logger import CLIUsageLogger
 from ..exceptions import (
     AnonyfilesError,
@@ -19,6 +15,10 @@ from ..exceptions import (
     FileIOError,
     ProcessingError,
 )
+from ..managers.config_manager import ConfigManager
+from ..managers.path_manager import PathManager
+from ..managers.validation_manager import ValidationManager
+from ..ui.console_display import ConsoleDisplay
 
 
 class AnonymizeHandler:
@@ -28,17 +28,17 @@ class AnonymizeHandler:
     def process(
         self,
         input_file: Path,
-        config_path: Optional[Path],
-        output: Optional[Path],
-        log_entities: Optional[Path],
-        mapping_output: Optional[Path],
-        bundle_output: Optional[Path],
+        config_path: Path | None,
+        output: Path | None,
+        log_entities: Path | None,
+        mapping_output: Path | None,
+        bundle_output: Path | None,
         output_dir: Path,
         dry_run: bool,
         csv_no_header: bool,  # Reçoit l'option directe
-        has_header_opt: Optional[str],  # Reçoit l'option directe
-        exclude_entities: Optional[List[str]],
-        custom_replacements_json: Optional[str],
+        has_header_opt: str | None,  # Reçoit l'option directe
+        exclude_entities: list[str] | None,
+        custom_replacements_json: str | None,
         append_timestamp: bool,
         force: bool,
     ):
@@ -68,7 +68,7 @@ class AnonymizeHandler:
             f"📂 Anonymisation du fichier : [bold cyan]{input_file.name}[/bold cyan]"
         )
 
-        csv_has_header_bool: Optional[bool] = None
+        csv_has_header_bool: bool | None = None
         if has_header_opt is not None:
             csv_has_header_bool = has_header_opt.lower() == "true"
         else:

--- a/anonyfiles_cli/handlers/batch_handler.py
+++ b/anonyfiles_cli/handlers/batch_handler.py
@@ -1,24 +1,24 @@
 # anonyfiles_cli/handlers/batch_handler.py
 
 from pathlib import Path
-from typing import List, Optional
+
 import typer
 from rich.progress import (
-    Progress,
     BarColumn,
+    Progress,
     TextColumn,
     TimeElapsedColumn,
     TimeRemainingColumn,
 )
 
-from ..handlers.anonymize_handler import AnonymizeHandler
-from ..ui.console_display import ConsoleDisplay
 from ..exceptions import (
     AnonyfilesError,
     ConfigurationError,
     FileIOError,
     ProcessingError,
 )
+from ..handlers.anonymize_handler import AnonymizeHandler
+from ..ui.console_display import ConsoleDisplay
 
 
 class BatchHandler:
@@ -38,12 +38,12 @@ class BatchHandler:
         self,
         input_dir: Path,
         pattern: str,
-        output_dir: Optional[Path],
-        config: Optional[Path],
+        output_dir: Path | None,
+        config: Path | None,
         dry_run: bool,
         recursive: bool,
         csv_no_header: bool,  # Passer les options CSV si le batch doit les gérer uniformément
-        has_header_opt: Optional[str],
+        has_header_opt: str | None,
     ):
         """Run anonymization on all files within ``input_dir``.
 
@@ -179,7 +179,7 @@ class BatchHandler:
         self.console.console.print(f"❌ Erreurs : [red]{error_count}[/red]")
         self.console.console.print(f"📁 Dossier de sortie : [blue]{output_dir}[/blue]")
 
-    def _find_files(self, input_dir: Path, pattern: str, recursive: bool) -> List[Path]:
+    def _find_files(self, input_dir: Path, pattern: str, recursive: bool) -> list[Path]:
         """
         Trouve les fichiers à traiter dans le répertoire donné, en appliquant le pattern
         et l'option récursive.

--- a/anonyfiles_cli/handlers/deanonymize_handler.py
+++ b/anonyfiles_cli/handlers/deanonymize_handler.py
@@ -2,13 +2,13 @@
 
 import json
 from pathlib import Path
-from typing import Optional
+
 import typer  # Importez typer si vous comptez l'utiliser pour les messages ou confirmations
 
 from anonyfiles_core import DeanonymizationEngine
 from anonyfiles_core.anonymizer.file_utils import timestamp
 from anonyfiles_core.anonymizer.run_logger import log_run_event
-from ..ui.console_display import ConsoleDisplay
+
 from ..cli_logger import CLIUsageLogger
 from ..exceptions import (
     AnonyfilesError,
@@ -16,6 +16,7 @@ from ..exceptions import (
     FileIOError,
     ProcessingError,
 )
+from ..ui.console_display import ConsoleDisplay
 
 
 class DeanonymizeHandler:
@@ -26,8 +27,8 @@ class DeanonymizeHandler:
         self,
         input_file: Path,
         mapping_csv: Path,
-        output: Optional[Path],
-        report: Optional[Path],
+        output: Path | None,
+        report: Path | None,
         dry_run: bool,
         permissive: bool,
     ):

--- a/anonyfiles_cli/handlers/validation_handler.py
+++ b/anonyfiles_cli/handlers/validation_handler.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from typing import Optional
+from typing import ClassVar
 
 from ..exceptions import (
     ConfigurationError,
@@ -10,18 +10,26 @@ from ..exceptions import (
 
 
 class ValidationHandler:
-    SUPPORTED_EXTENSIONS = {".txt", ".log", ".csv", ".docx", ".xlsx", ".pdf", ".json"}
+    SUPPORTED_EXTENSIONS: ClassVar[set[str]] = {
+        ".txt",
+        ".log",
+        ".csv",
+        ".docx",
+        ".xlsx",
+        ".pdf",
+        ".json",
+    }
 
     @classmethod
     def validate_anonymize_inputs(
         cls,
         input_file: Path,
-        output: Optional[
-            Path
-        ],  # Non utilisé pour la validation d'extension, mais peut être utile si on valide le chemin de sortie
-        custom_replacements_json: Optional[str],
+        output: (
+            Path | None
+        ),  # Non utilisé pour la validation d'extension, mais peut être utile si on valide le chemin de sortie
+        custom_replacements_json: str | None,
         csv_no_header: bool,
-        has_header_opt: Optional[str],
+        has_header_opt: str | None,
     ):
         """Validate inputs for anonymization.
 
@@ -73,7 +81,7 @@ class ValidationHandler:
 
     @classmethod
     def _validate_csv_options(
-        cls, input_file: Path, csv_no_header: bool, has_header_opt: Optional[str]
+        cls, input_file: Path, csv_no_header: bool, has_header_opt: str | None
     ):
         """Valide la cohérence des options CSV avec le type de fichier."""
         if csv_no_header and input_file.suffix.lower() != ".csv":
@@ -85,7 +93,7 @@ class ValidationHandler:
             raise ConfigurationError("--has-header-opt doit être 'true' ou 'false'.")
 
     @classmethod
-    def _validate_custom_replacements(cls, custom_replacements_json: Optional[str]):
+    def _validate_custom_replacements(cls, custom_replacements_json: str | None):
         """Valide le format JSON des règles de remplacement personnalisées."""
         if custom_replacements_json:
             try:

--- a/anonyfiles_cli/main.py
+++ b/anonyfiles_cli/main.py
@@ -1,23 +1,26 @@
 # anonyfiles_cli/main.py
-# -*- coding: utf-8 -*-
 #
 # Entrée du programme CLI
-import typer
 import logging
+
+import typer
+
+from anonyfiles_cli.cli_logger import CLIUsageLogger
 
 # Importe les applications Typer des modules de commandes séparés
 from anonyfiles_cli.commands import (
     anonymize,
-    deanonymize,
-    config,
     batch,
-    utils,
     clean_job,
+    config,
+    deanonymize,
     logs,
+    utils,
 )
 from anonyfiles_cli.managers.config_manager import ConfigManager
 from anonyfiles_cli.ui.console_display import ConsoleDisplay
-from anonyfiles_cli.cli_logger import CLIUsageLogger
+
+logger = logging.getLogger(__name__)
 
 app = typer.Typer(
     pretty_exceptions_show_locals=False,
@@ -63,7 +66,7 @@ def main_callback(
     """
     logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO, force=True)
     if verbose:
-        logging.debug("Verbose mode enabled")
+        logger.debug("Verbose mode enabled")
     CLIUsageLogger.VERBOSE = verbose
 
     user_config_path = ConfigManager.DEFAULT_USER_CONFIG_FILE

--- a/anonyfiles_cli/managers/config_manager.py
+++ b/anonyfiles_cli/managers/config_manager.py
@@ -1,13 +1,14 @@
 # anonyfiles_cli/managers/config_manager.py
 
-import yaml
 import logging
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Any
+
+import yaml
 
 from ..exceptions import ConfigurationError
-from .validation_manager import ValidationManager
 from ..utils.default_paths import get_default_output_dir
+from .validation_manager import ValidationManager
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +37,7 @@ class ConfigManager:
     )
 
     @classmethod
-    def _load_yaml_file(cls, file_path: Path) -> Dict[str, Any]:
+    def _load_yaml_file(cls, file_path: Path) -> dict[str, Any]:
         """Charge un fichier YAML de manière sécurisée."""
         if not file_path.is_file():
             return {}
@@ -52,7 +53,7 @@ class ConfigManager:
             raise ConfigurationError(f"Erreur lors de la lecture de '{file_path}': {e}")
 
     @classmethod
-    def get_user_config(cls) -> Dict[str, Any]:
+    def get_user_config(cls) -> dict[str, Any]:
         """Charge la configuration spécifique à l'utilisateur."""
         try:
             return cls._load_yaml_file(cls.DEFAULT_USER_CONFIG_FILE)
@@ -62,8 +63,8 @@ class ConfigManager:
 
     @classmethod
     def get_effective_config(
-        cls, cli_provided_config_path: Optional[Path]
-    ) -> Dict[str, Any]:
+        cls, cli_provided_config_path: Path | None
+    ) -> dict[str, Any]:
         """
         Charge la configuration en respectant la priorité :
         1. Fichier de configuration fourni via la CLI.

--- a/anonyfiles_cli/managers/path_manager.py
+++ b/anonyfiles_cli/managers/path_manager.py
@@ -1,17 +1,17 @@
 # anonyfiles_cli/managers/path_manager.py
 
 from pathlib import Path
-from typing import Dict, Optional
+
+from anonyfiles_core.anonymizer.file_utils import (
+    default_log,
+    default_mapping,
+    default_output,
+    ensure_folder,
+    make_run_dir,
+)
 
 # C'EST LA LIGNE CLÉ À VÉRIFIER : DOIT ÊTRE UN IMPORT RELATIF AVEC DEUX POINTS (..)
 from ..exceptions import FileIOError
-from anonyfiles_core.anonymizer.file_utils import (
-    ensure_folder,
-    make_run_dir,
-    default_output,
-    default_mapping,
-    default_log,
-)
 
 
 class PathManager:
@@ -37,7 +37,7 @@ class PathManager:
         self.base_output_dir = base_output_dir
         self.run_id = run_id
         self.append_timestamp = append_timestamp
-        self._run_dir: Optional[Path] = None
+        self._run_dir: Path | None = None
 
     @property
     def run_dir(self) -> Path:
@@ -48,12 +48,12 @@ class PathManager:
 
     def resolve_paths(
         self,
-        output_override: Optional[Path],
-        mapping_override: Optional[Path],
-        log_entities_override: Optional[Path],
+        output_override: Path | None,
+        mapping_override: Path | None,
+        log_entities_override: Path | None,
         dry_run: bool,
-        bundle_override: Optional[Path] = None,
-    ) -> Dict[str, Path]:
+        bundle_override: Path | None = None,
+    ) -> dict[str, Path]:
         """
         Résout tous les chemins de fichiers de sortie.
         Si un chemin n'est pas fourni, un chemin par default est généré dans le répertoire de run.
@@ -63,7 +63,7 @@ class PathManager:
         :param dry_run: Si True, ne crée pas de répertoires pour les chemins par default.
         :return: Un dictionnaire contenant les chemins résolus.
         """
-        paths: Dict[str, Path] = {}
+        paths: dict[str, Path] = {}
 
         # Chemin du fichier de sortie anonymisé
         if output_override:

--- a/anonyfiles_cli/managers/validation_manager.py
+++ b/anonyfiles_cli/managers/validation_manager.py
@@ -1,10 +1,11 @@
 # anonyfiles_cli/managers/validation_manager.py
 
-import yaml
 import logging  # Ajout de l'import logging
 from pathlib import Path
-from typing import List, Dict, Any, Optional, Union
+from typing import Any
+
 import typer
+import yaml
 from cerberus import Validator
 
 from anonyfiles_core.anonymizer.engine_options import (
@@ -72,7 +73,7 @@ class ValidationManager:
     """
 
     @staticmethod
-    def load_and_validate_config(config_path: Path) -> Dict[str, Any]:
+    def load_and_validate_config(config_path: Path) -> dict[str, Any]:
         """
         Charge et valide un fichier de configuration YAML.
         :param config_path: Chemin vers le fichier de configuration.
@@ -106,8 +107,8 @@ class ValidationManager:
 
     @staticmethod
     def parse_custom_replacements(
-        custom_replacements_json: Optional[str],
-    ) -> List[Dict[str, Union[str, bool]]]:
+        custom_replacements_json: str | None,
+    ) -> list[dict[str, str | bool]]:
         """Parse et valide la chaîne JSON des règles de remplacement personnalisées.
 
         Délègue le parsing de base au helper partagé (`engine_options`), puis
@@ -138,7 +139,7 @@ class ValidationManager:
         return parsed
 
     @staticmethod
-    def check_overwrite(paths_to_check: List[Path], force: bool):
+    def check_overwrite(paths_to_check: list[Path], force: bool):
         """
         Vérifie si des fichiers de sortie existent déjà et demande confirmation si --force n'est pas utilisé.
         :param paths_to_check: Liste des chemins de fichiers à vérifier.
@@ -167,7 +168,7 @@ class ValidationManager:
             )  # Modifié pour utiliser logger.warning
 
     @staticmethod
-    def validate_config_dict(config: Dict[str, Any]) -> None:
+    def validate_config_dict(config: dict[str, Any]) -> None:
         """Valide un dictionnaire de configuration selon ``SCHEMA``."""
         v = Validator(SCHEMA)
         if not v.validate(config):

--- a/anonyfiles_cli/tui.py
+++ b/anonyfiles_cli/tui.py
@@ -1,18 +1,19 @@
 from pathlib import Path
+from typing import ClassVar
 
+from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal
 from textual.widgets import (
-    Header,
-    Footer,
     Button,
     DataTable,
+    Footer,
+    Header,
     Input,
     Label,
-    Static,
     RichLog,
+    Static,
 )
-from rich.text import Text
 
 
 class LogViewer(Static):
@@ -103,7 +104,7 @@ class LogsApp(App):
     }
     """
 
-    BINDINGS = [
+    BINDINGS: ClassVar[list[tuple[str, str, str]]] = [
         ("q", "quit", "Quitter"),
         ("r", "reload", "Recharger"),
         ("c", "clear_logs", "Effacer vue"),

--- a/anonyfiles_cli/ui/console_display.py
+++ b/anonyfiles_cli/ui/console_display.py
@@ -1,10 +1,11 @@
 # anonyfiles_cli/ui/console_display.py
 
+import contextlib
 import traceback
 from pathlib import Path
-from typing import Dict, Any
-import typer
+from typing import Any
 
+import typer
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -33,7 +34,7 @@ class ConsoleDisplay:
         self.console.print("")
 
     def display_results(
-        self, result: Dict[str, Any], dry_run: bool, paths: Dict[str, Path]
+        self, result: dict[str, Any], dry_run: bool, paths: dict[str, Path]
     ):
         """
         Affiche un résumé des résultats de l'anonymisation.
@@ -101,12 +102,10 @@ class ConsoleDisplay:
 
         command_name = None
         params = None
-        try:
+        with contextlib.suppress(Exception):
             ctx = typer.get_current_context()
             command_name = ctx.command_path
             params = ctx.params
-        except Exception:
-            pass
 
         if isinstance(error, ConfigurationError):
             if "spaCy model" in str(error) and "Install manualy" in str(error):

--- a/anonyfiles_cli/ui/interactive_mode.py
+++ b/anonyfiles_cli/ui/interactive_mode.py
@@ -1,7 +1,5 @@
 """Fonctionnalités interactives pour la CLI."""
 
-from typing import List
-
 import typer
 
 from .console_display import ConsoleDisplay
@@ -19,7 +17,7 @@ ENTITY_CHOICES = [
 ]
 
 
-def prompt_entities_to_exclude(console: ConsoleDisplay) -> List[str]:
+def prompt_entities_to_exclude(console: ConsoleDisplay) -> list[str]:
     """Demande à l'utilisateur quelles entités anonymiser.
 
     Retourne la liste des labels à exclure en fonction du choix.

--- a/anonyfiles_cli/utils/system_utils.py
+++ b/anonyfiles_cli/utils/system_utils.py
@@ -2,8 +2,9 @@
 
 import os
 import sys
-import typer
 from pathlib import Path
+
+import typer
 
 # Importation conditionnelle de chardet
 try:

--- a/anonyfiles_cli/validate_yaml_cerberus.py
+++ b/anonyfiles_cli/validate_yaml_cerberus.py
@@ -1,6 +1,7 @@
+from pathlib import Path
+
 import yaml
 from cerberus import Validator
-from pathlib import Path
 
 SCHEMA = {
     "spacy_model": {"type": "string", "required": True},

--- a/anonyfiles_core/__init__.py
+++ b/anonyfiles_core/__init__.py
@@ -1,5 +1,5 @@
-from .anonymizer.engine import AnonyfilesEngine
-from .anonymizer.deanonymization_engine import DeanonymizationEngine
 from .anonymizer.bundle_handler import create_bundle
+from .anonymizer.deanonymization_engine import DeanonymizationEngine
+from .anonymizer.engine import AnonyfilesEngine
 
 __all__ = ["AnonyfilesEngine", "DeanonymizationEngine", "create_bundle"]

--- a/anonyfiles_core/anonymizer/base_processor.py
+++ b/anonyfiles_core/anonymizer/base_processor.py
@@ -1,7 +1,7 @@
 # anonymizer/base_processor.py
-from typing import Any
-from pathlib import Path
 import asyncio
+from pathlib import Path
+from typing import Any
 
 from .type_defs import TextBlocks
 

--- a/anonyfiles_core/anonymizer/bundle_handler.py
+++ b/anonyfiles_core/anonymizer/bundle_handler.py
@@ -1,15 +1,15 @@
 import json
 import zipfile
 from pathlib import Path
-from typing import Optional, List, Dict, Any
+from typing import Any
 
 
 def create_bundle(
     bundle_path: Path,
-    anonymized_path: Optional[Path],
-    mapping_path: Optional[Path],
-    audit_log: List[Dict[str, Any]],
-    log_entities_path: Optional[Path] = None,
+    anonymized_path: Path | None,
+    mapping_path: Path | None,
+    audit_log: list[dict[str, Any]],
+    log_entities_path: Path | None = None,
 ) -> None:
     """Create a zip archive containing output files and audit log."""
     bundle_path.parent.mkdir(parents=True, exist_ok=True)

--- a/anonyfiles_core/anonymizer/csv_processor.py
+++ b/anonyfiles_core/anonymizer/csv_processor.py
@@ -1,13 +1,15 @@
 # anonyfiles_cli/anonymizer/csv_processor.py
 
 import csv
-from pathlib import Path  # Corrected: Removed invalid non-printable character
-from typing import Any
-from .base_processor import BaseProcessor
-from .type_defs import TextBlocks
-import aiofiles
 import io
 import logging
+from pathlib import Path  # Corrected: Removed invalid non-printable character
+from typing import Any
+
+import aiofiles
+
+from .base_processor import BaseProcessor
+from .type_defs import TextBlocks
 
 logger = logging.getLogger(__name__)
 # apply_positional_replacements n'est plus nécessaire ici car le traitement se fait dans anonyfiles_core

--- a/anonyfiles_core/anonymizer/custom_rules_processor.py
+++ b/anonyfiles_core/anonymizer/custom_rules_processor.py
@@ -1,7 +1,8 @@
 # anonyfiles_cli/anonymizer/custom_rules_processor.py
 
 import re
-from typing import List, Dict, Any, Optional
+from typing import Any
+
 import typer
 
 from .audit import AuditLogger
@@ -14,12 +15,12 @@ class CustomRulesProcessor:
 
     def __init__(
         self,
-        custom_replacement_rules: Optional[List[Dict[str, Any]]],
+        custom_replacement_rules: list[dict[str, Any]] | None,
         audit_logger: AuditLogger,
     ):
-        self.custom_rules: List[Dict[str, Any]] = []
+        self.custom_rules: list[dict[str, Any]] = []
         self.audit_logger = audit_logger
-        self.custom_replacements_mapping: Dict[str, str] = {}
+        self.custom_replacements_mapping: dict[str, str] = {}
         self.custom_replacements_count = 0
 
         if custom_replacement_rules:
@@ -67,7 +68,7 @@ class CustomRulesProcessor:
             pattern_str = rule.get("pattern")
             replacement_base = rule.get("replacement", "[CUSTOM_REDACTED]")
             is_regex = rule.get("isRegex", False)
-            compiled_pattern: Optional[re.Pattern] = rule.get("compiled_pattern")
+            compiled_pattern: re.Pattern | None = rule.get("compiled_pattern")
 
             if not pattern_str:
                 continue
@@ -93,9 +94,7 @@ class CustomRulesProcessor:
                             # Pour injecter le compteur, on l'ajoute à la fin.
 
                             # Heuristique : Si le remplacement finit par ] ou }, on insère avant
-                            if replacement_base.endswith(
-                                "]"
-                            ) or replacement_base.endswith("}"):
+                            if replacement_base.endswith(("]", "}")):
                                 final_token = f"{replacement_base[:-1]}_{current_count}{replacement_base[-1]}"
                             else:
                                 final_token = f"{replacement_base}_{current_count}"
@@ -134,9 +133,7 @@ class CustomRulesProcessor:
                     else:
                         rule["match_counter"] += 1
                         current_count = rule["match_counter"]
-                        if replacement_base.endswith("]") or replacement_base.endswith(
-                            "}"
-                        ):
+                        if replacement_base.endswith(("]", "}")):
                             token = f"{replacement_base[:-1]}_{current_count}{replacement_base[-1]}"
                         else:
                             token = f"{replacement_base}_{current_count}"
@@ -165,7 +162,7 @@ class CustomRulesProcessor:
 
         return modified_text
 
-    def get_custom_replacements_mapping(self) -> Dict[str, str]:
+    def get_custom_replacements_mapping(self) -> dict[str, str]:
         return self.custom_replacements_mapping
 
     def get_custom_replacements_count(self) -> int:

--- a/anonyfiles_core/anonymizer/deanonymization_engine.py
+++ b/anonyfiles_core/anonymizer/deanonymization_engine.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any
 
 from .deanonymize import Deanonymizer
 
@@ -16,7 +16,7 @@ class DeanonymizationEngine:
         mapping_path: Path,
         permissive: bool = False,
         dry_run: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Run deanonymization and return result information."""
         try:
             deanonymizer = Deanonymizer(str(mapping_path), strict=not permissive)
@@ -43,7 +43,7 @@ class DeanonymizationEngine:
                 "warnings": warnings,
             }
         except Exception as e:
-            logger.error("Deanonymization failed", exc_info=True)
+            logger.exception("Deanonymization failed")
             return {
                 "status": "error",
                 "error": str(e),

--- a/anonyfiles_core/anonymizer/deanonymize.py
+++ b/anonyfiles_core/anonymizer/deanonymize.py
@@ -1,9 +1,9 @@
 # /home/debian/anonyfiles/anonyfiles_cli/anonymizer/deanonymize.py
 
 import csv
-from collections import defaultdict
-from typing import Dict, Set, Tuple, List, Optional
 import re
+from collections import defaultdict
+
 from .format_utils import ANY_PLACEHOLDER_REGEX, parse_placeholder
 
 
@@ -11,11 +11,11 @@ class Deanonymizer:
     def __init__(self, mapping_path: str, strict: bool = True):
         self.mapping_path = mapping_path
         self.strict = strict
-        self.code_to_originals: Dict[str, Set[str]] = defaultdict(set)
-        self.warnings: List[str] = []
-        self.map_loading_warnings: List[str] = []
-        self.collisions: Dict[str, Set[str]] = {}
-        self.unknown_codes_in_text: Set[str] = set()
+        self.code_to_originals: dict[str, set[str]] = defaultdict(set)
+        self.warnings: list[str] = []
+        self.map_loading_warnings: list[str] = []
+        self.collisions: dict[str, set[str]] = {}
+        self.unknown_codes_in_text: set[str] = set()
         self._load_mapping()
 
     def _load_mapping(self):
@@ -43,7 +43,6 @@ class Deanonymizer:
                 # Assuming ruff is correct and they are truly unused.
                 # But wait, lines 45-50 are doing work (next(...)). If I remove assignment, I should simple call next() if side effect needed, or remove completely if not needed to advance iterator.
                 # These seem to be lookups for column names. If result is not used, lookups are useless.
-                pass
 
                 if not code_field or not original_field:
                     self.map_loading_warnings.append(
@@ -72,7 +71,7 @@ class Deanonymizer:
                             )
                     except Exception as e_row:
                         self.map_loading_warnings.append(
-                            f"Erreur à la ligne {row_number} dans {self.mapping_path}: {str(e_row)}."
+                            f"Erreur à la ligne {row_number} dans {self.mapping_path}: {e_row!s}."
                         )
 
             temp_collisions = {}
@@ -90,10 +89,10 @@ class Deanonymizer:
             )
         except Exception as e:
             self.map_loading_warnings.append(
-                f"Erreur majeure lors du chargement du fichier mapping {self.mapping_path}: {str(e)}"
+                f"Erreur majeure lors du chargement du fichier mapping {self.mapping_path}: {e!s}"
             )
 
-    def deanonymize_text(self, text: str, dry_run: bool = False) -> Tuple[str, dict]:
+    def deanonymize_text(self, text: str, dry_run: bool = False) -> tuple[str, dict]:
         self.warnings = list(self.map_loading_warnings)
         self.unknown_codes_in_text = set()
 
@@ -147,15 +146,13 @@ class Deanonymizer:
         }
 
         report = {
-            "distinct_codes_in_text_list": sorted(
-                list(all_distinct_codes_found_in_text)
-            ),
+            "distinct_codes_in_text_list": sorted(all_distinct_codes_found_in_text),
             "distinct_codes_in_text_count": len(all_distinct_codes_found_in_text),
             "codes_from_text_found_in_mapping_count": len(
                 codes_in_mapping_that_were_referenced
             ),
             "codes_from_text_not_found_in_mapping_list": sorted(
-                list(self.unknown_codes_in_text)
+                self.unknown_codes_in_text
             ),
             "codes_from_text_not_found_in_mapping_count": len(
                 self.unknown_codes_in_text
@@ -179,7 +176,7 @@ class Deanonymizer:
         }
         return result_text, report
 
-    def generate_report(self, report: dict, output_path: Optional[str] = None):
+    def generate_report(self, report: dict, output_path: str | None = None):
         lines = [
             "=== Rapport de Désanonymisation ===",
             f"Mode dry-run: {report['dry_run']}",

--- a/anonyfiles_core/anonymizer/engine.py
+++ b/anonyfiles_core/anonymizer/engine.py
@@ -1,23 +1,23 @@
 # anonyfiles_cli/anonymizer/engine.py
 
+import logging
 import re
 from pathlib import Path
-from typing import Optional, List, Dict, Any
-import logging
+from typing import Any
 
-from .spacy_engine import SpaCyEngine
-from .utils import apply_positional_replacements
 from .audit import AuditLogger
 from .custom_rules_processor import CustomRulesProcessor
-from .ner_processor import NERProcessor
 from .file_processor_factory import FileProcessorFactory
-from .replacement_generator import ReplacementGenerator
-from .writer import AnonymizedFileWriter
-from .type_defs import EntityLabelOverrides, EntitySpansByBlock
+from .ner_processor import NERProcessor
 from .privacy_warning_scanner import (
     privacy_warning_count,
     scan_blocks_for_privacy_warnings,
 )
+from .replacement_generator import ReplacementGenerator
+from .spacy_engine import SpaCyEngine
+from .type_defs import EntityLabelOverrides, EntitySpansByBlock
+from .utils import apply_positional_replacements
+from .writer import AnonymizedFileWriter
 
 logger = logging.getLogger(__name__)
 
@@ -111,13 +111,13 @@ class AnonyfilesEngine:
 
     def __init__(
         self,
-        config: Dict[str, Any],
-        exclude_entities_cli: Optional[List[str]] = None,
-        custom_replacement_rules: Optional[List[Dict[str, str]]] = None,
-        ignored_entity_texts: Optional[set[str]] = None,
-        entity_label_overrides: Optional[Dict[str, str]] = None,
-        manual_entities: Optional[List[Dict[str, str]]] = None,
-        strict_mode: Optional[bool] = None,
+        config: dict[str, Any],
+        exclude_entities_cli: list[str] | None = None,
+        custom_replacement_rules: list[dict[str, str]] | None = None,
+        ignored_entity_texts: set[str] | None = None,
+        entity_label_overrides: dict[str, str] | None = None,
+        manual_entities: list[dict[str, str]] | None = None,
+        strict_mode: bool | None = None,
     ):
         self.config = config or {}
         self.ignored_entity_texts = ignored_entity_texts or set()
@@ -186,7 +186,7 @@ class AnonyfilesEngine:
         )
 
         # Initialisation du Writer (dépend de dry_run, sera initialisé dans anonymize())
-        self.writer: Optional[AnonymizedFileWriter] = None
+        self.writer: AnonymizedFileWriter | None = None
 
         logger.debug(
             "DEBUG (AnonyfilesEngine Init): Entités à exclure (config + CLI) : %s",
@@ -195,7 +195,7 @@ class AnonyfilesEngine:
 
     def _scan_privacy_warnings(
         self,
-        final_blocks: List[str],
+        final_blocks: list[str],
         ignored_values: list[str] | None = None,
     ) -> list[dict[str, object]]:
         return scan_blocks_for_privacy_warnings(
@@ -204,7 +204,7 @@ class AnonyfilesEngine:
             ignored_values=ignored_values or [],
         )
 
-    def _process_content(self, original_blocks: List[str]):
+    def _process_content(self, original_blocks: list[str]):
         """
         Logique métier pure d'anonymisation sur des blocs de texte.
         Retourne un dictionnaire contenant les résultats intermédiaires ou finaux.
@@ -329,15 +329,15 @@ class AnonyfilesEngine:
     def anonymize(
         self,
         input_path: Path,
-        output_path: Optional[Path],
-        entities: Optional[
-            List[str]
-        ],  # Ce paramètre n'est plus utilisé directement ici, la logique de filtrage est dans NERProcessor
+        output_path: Path | None,
+        entities: (
+            list[str] | None
+        ),  # Ce paramètre n'est plus utilisé directement ici, la logique de filtrage est dans NERProcessor
         dry_run: bool,
-        log_entities_path: Optional[Path],
-        mapping_output_path: Optional[Path],
+        log_entities_path: Path | None,
+        mapping_output_path: Path | None,
         **kwargs,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         self.audit_logger.reset()
         self.custom_rules_processor.reset()
         self.writer = AnonymizedFileWriter(dry_run)
@@ -442,13 +442,13 @@ class AnonyfilesEngine:
     async def anonymize_async(
         self,
         input_path: Path,
-        output_path: Optional[Path],
-        entities: Optional[List[str]],
+        output_path: Path | None,
+        entities: list[str] | None,
         dry_run: bool,
-        log_entities_path: Optional[Path],
-        mapping_output_path: Optional[Path],
+        log_entities_path: Path | None,
+        mapping_output_path: Path | None,
         **kwargs,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         self.audit_logger.reset()
         self.custom_rules_processor.reset()
         self.writer = AnonymizedFileWriter(dry_run)

--- a/anonyfiles_core/anonymizer/engine_options.py
+++ b/anonyfiles_core/anonymizer/engine_options.py
@@ -15,8 +15,9 @@ place and both front-ends stay consistent.
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any
 
 # Mapping "toggle key in request" -> "entity label used by the engine".
 # Kept as a tuple of tuples so the iteration order is deterministic and the
@@ -38,10 +39,10 @@ class CustomRulesParseError(ValueError):
 
 
 def parse_custom_replacement_rules(
-    raw: Optional[str],
+    raw: str | None,
     *,
     strict: bool = False,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Parse a JSON string into a list of custom replacement rule dicts.
 
     Empty / ``None`` input yields ``[]``. When ``strict`` is true, malformed
@@ -80,7 +81,7 @@ def build_exclude_entities(
     toggles: Mapping[str, Any],
     *,
     has_custom_rules: bool = False,
-) -> List[str]:
+) -> list[str]:
     """Translate per-entity boolean toggles into an ``exclude_entities`` list.
 
     A missing key defaults to ``True`` (entity *is* anonymized) which matches
@@ -89,12 +90,12 @@ def build_exclude_entities(
     misc entities don't get double-processed.
     """
 
-    excluded: List[str] = []
+    excluded: list[str] = []
     for toggle_key, entity_label in ENTITY_TOGGLE_MAP:
         if not bool(toggles.get(toggle_key, True)):
             excluded.append(entity_label)
 
-    misc_default = False if has_custom_rules else True
+    misc_default = not has_custom_rules
     if not bool(toggles.get("anonymizeMisc", misc_default)):
         excluded.append("MISC")
     return excluded
@@ -103,10 +104,10 @@ def build_exclude_entities(
 def build_processor_kwargs(
     input_path: Path,
     *,
-    has_header: Optional[bool] = None,
-) -> Dict[str, Any]:
+    has_header: bool | None = None,
+) -> dict[str, Any]:
     """Build keyword arguments forwarded to the engine's file processor."""
-    processor_kwargs: Dict[str, Any] = {}
+    processor_kwargs: dict[str, Any] = {}
     if input_path.suffix.lower() == ".csv" and has_header is not None:
         processor_kwargs["has_header"] = has_header
     return processor_kwargs

--- a/anonyfiles_core/anonymizer/excel_processor.py
+++ b/anonyfiles_core/anonymizer/excel_processor.py
@@ -1,10 +1,12 @@
 # anonymizer/excel_processor.py
 
-import pandas as pd
-import numpy as np
-from pathlib import Path
 import logging
+from pathlib import Path
 from typing import Any
+
+import numpy as np
+import pandas as pd
+
 from .base_processor import BaseProcessor
 from .type_defs import ExcelSheetMetadata, TextBlocks
 

--- a/anonyfiles_core/anonymizer/file_processor_factory.py
+++ b/anonyfiles_core/anonymizer/file_processor_factory.py
@@ -1,12 +1,12 @@
 # anonyfiles_cli/anonymizer/file_processor_factory.py
 
 from .base_processor import BaseProcessor
-from .txt_processor import TxtProcessor
 from .csv_processor import CsvProcessor
-from .word_processor import DocxProcessor
 from .excel_processor import ExcelProcessor
-from .pdf_processor import PdfProcessor
 from .json_processor import JsonProcessor
+from .pdf_processor import PdfProcessor
+from .txt_processor import TxtProcessor
+from .word_processor import DocxProcessor
 
 PROCESSOR_MAP: dict[str, type[BaseProcessor]] = {
     ".txt": TxtProcessor,

--- a/anonyfiles_core/anonymizer/file_utils.py
+++ b/anonyfiles_core/anonymizer/file_utils.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 
 
 def timestamp() -> str:

--- a/anonyfiles_core/anonymizer/json_processor.py
+++ b/anonyfiles_core/anonymizer/json_processor.py
@@ -4,6 +4,7 @@ import json
 import logging
 from pathlib import Path
 from typing import Any
+
 import aiofiles
 
 from .base_processor import BaseProcessor

--- a/anonyfiles_core/anonymizer/ner_processor.py
+++ b/anonyfiles_core/anonymizer/ner_processor.py
@@ -1,20 +1,19 @@
 # anonyfiles_cli/anonymizer/ner_processor.py
 
+import logging
 import re
 import unicodedata
-from typing import List, Dict, Tuple, Set
-import logging  #
 
-from .spacy_engine import SpaCyEngine
 from .spacy_engine import (
     ADDRESS_REGEX,
     DATE_REGEX,
     EMAIL_REGEX,
     IBAN_REGEX,
     PHONE_REGEX,
+    SpaCyEngine,
 )
 
-logger = logging.getLogger(__name__)  #
+logger = logging.getLogger(__name__)
 
 _EXTRA_FRENCH_FIRST_NAMES = {
     "ambre",
@@ -122,7 +121,7 @@ def _trim_entity_span(
 
 
 def _overlaps_existing_span(
-    start: int, end: int, entities: List[Tuple[str, str, int, int]]
+    start: int, end: int, entities: list[tuple[str, str, int, int]]
 ) -> bool:
     return any(
         start < existing_end and end > existing_start
@@ -135,8 +134,8 @@ def _add_non_overlapping_entity(
     label: str,
     start: int,
     end: int,
-    entities: List[Tuple[str, str, int, int]],
-    enabled_labels: Set[str],
+    entities: list[tuple[str, str, int, int]],
+    enabled_labels: set[str],
 ) -> None:
     if label not in enabled_labels:
         return
@@ -152,7 +151,7 @@ def _add_non_overlapping_entity(
     entities.append(clean_entity)
 
 
-def _fallback_to_misc(label: str, enabled_labels: Set[str]) -> str | None:
+def _fallback_to_misc(label: str, enabled_labels: set[str]) -> str | None:
     if label in enabled_labels:
         return label
     if "MISC" in enabled_labels:
@@ -160,7 +159,7 @@ def _fallback_to_misc(label: str, enabled_labels: Set[str]) -> str | None:
     return None
 
 
-def _context_label_for_key(key: str, enabled_labels: Set[str]) -> str | None:
+def _context_label_for_key(key: str, enabled_labels: set[str]) -> str | None:
     normalized_key = _normalize_name_key(key)
     label = _STRICT_CONTEXT_LABEL_BY_KEY.get(normalized_key)
     if label is None:
@@ -180,8 +179,8 @@ class NERProcessor:
     def __init__(
         self,
         spacy_engine: SpaCyEngine,
-        enabled_labels: Set[str],
-        excluded_labels: Set[str],
+        enabled_labels: set[str],
+        excluded_labels: set[str],
         strict_mode: bool = False,
     ):
         self.spacy_engine = spacy_engine
@@ -190,14 +189,14 @@ class NERProcessor:
         self.strict_mode = strict_mode
 
         self.final_enabled_labels_for_spacy = self.enabled_labels - self.excluded_labels
-        logger.debug(  #
-            "DEBUG (NERProcessor Init): Labels spaCy effectivement activés pour la détection : %s",  #
-            self.final_enabled_labels_for_spacy,  #
+        logger.debug(
+            "DEBUG (NERProcessor Init): Labels spaCy effectivement activés pour la détection : %s",
+            self.final_enabled_labels_for_spacy,
         )
 
     def detect_entities_in_blocks(
-        self, text_blocks: List[str]
-    ) -> Tuple[List[Tuple[str, str]], List[List[Tuple[str, str, int, int]]]]:
+        self, text_blocks: list[str]
+    ) -> tuple[list[tuple[str, str]], list[list[tuple[str, str, int, int]]]]:
         """
         Détecte les entités dans une liste de blocs de texte.
         Retourne :
@@ -205,10 +204,10 @@ class NERProcessor:
         2. Une liste de listes de tuples (entity_text, label, start_char, end_char) par bloc,
            incluant les offsets pour le remplacement positionnel.
         """
-        all_unique_entities_across_blocks: Dict[str, Tuple[str, str]] = (
+        all_unique_entities_across_blocks: dict[str, tuple[str, str]] = (
             {}
         )  # {entity_text: (label, source_type)}
-        spacy_entities_per_block_with_offsets: List[List[Tuple[str, str, int, int]]] = (
+        spacy_entities_per_block_with_offsets: list[list[tuple[str, str, int, int]]] = (
             []
         )
 
@@ -223,7 +222,7 @@ class NERProcessor:
         PRIORITY_REGEX_LABELS = {"EMAIL", "DATE", "PHONE", "IBAN", "ADDRESS"}
 
         for block_text in text_blocks:
-            detected_entities_for_this_block: List[Tuple[str, str, int, int]] = (
+            detected_entities_for_this_block: list[tuple[str, str, int, int]] = (
                 []
             )  # Cette variable est celle qui est remplie
 
@@ -275,8 +274,8 @@ class NERProcessor:
                     )
 
                 # 3. Nettoyer et dédupliquer les entités du bloc avec gestion de priorité
-                processed_entities_for_this_block: List[Tuple[str, str, int, int]] = []
-                best_entities_by_span: Dict[Tuple[int, int], Tuple[str, str]] = {}
+                processed_entities_for_this_block: list[tuple[str, str, int, int]] = []
+                best_entities_by_span: dict[tuple[int, int], tuple[str, str]] = {}
 
                 # La variable à trier est bien 'detected_entities_for_this_block'
                 detected_entities_for_this_block.sort(key=lambda x: x[2])
@@ -285,7 +284,7 @@ class NERProcessor:
                     span = (start, end)
 
                     if span in best_entities_by_span:
-                        existing_text, existing_label = best_entities_by_span[span]
+                        _existing_text, existing_label = best_entities_by_span[span]
 
                         if (
                             ent_label in PRIORITY_REGEX_LABELS
@@ -342,7 +341,7 @@ class NERProcessor:
     def _add_strict_entities(
         self,
         block_text: str,
-        entities: List[Tuple[str, str, int, int]],
+        entities: list[tuple[str, str, int, int]],
     ) -> None:
         enabled = self.final_enabled_labels_for_spacy
 

--- a/anonyfiles_core/anonymizer/pdf_processor.py
+++ b/anonyfiles_core/anonymizer/pdf_processor.py
@@ -1,8 +1,11 @@
 # anonymizer/pdf_processor.py
 
-import fitz  # PyMuPDF
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
+
+import fitz  # PyMuPDF
+
 from .base_processor import BaseProcessor
 from .type_defs import EntitySpansByBlock, ReplacementMap, TextBlocks
 

--- a/anonyfiles_core/anonymizer/replacement_generator.py
+++ b/anonyfiles_core/anonymizer/replacement_generator.py
@@ -1,9 +1,9 @@
 # anonyfiles_cli/anonymizer/replacement_generator.py
 
-from typing import List, Dict, Any, Tuple
+from typing import Any
 
-from .replacer import ReplacementSession
 from .audit import AuditLogger
+from .replacer import ReplacementSession
 
 
 class ReplacementGenerator:
@@ -12,7 +12,7 @@ class ReplacementGenerator:
     et les journalise dans l'audit logger.
     """
 
-    def __init__(self, config: Dict[str, Any], audit_logger: AuditLogger):
+    def __init__(self, config: dict[str, Any], audit_logger: AuditLogger):
         self.config = config
         self.audit_logger = audit_logger
         self.replacement_rules_spacy_config = self.config.get("replacements", {})
@@ -20,9 +20,9 @@ class ReplacementGenerator:
 
     def generate_spacy_replacements(
         self,
-        unique_spacy_entities: List[Tuple[str, str]],
-        entities_per_block_with_offsets: List[List[Tuple[str, str, int, int]]],
-    ) -> Tuple[Dict[str, str], Dict[str, str]]:
+        unique_spacy_entities: list[tuple[str, str]],
+        entities_per_block_with_offsets: list[list[tuple[str, str, int, int]]],
+    ) -> tuple[dict[str, str], dict[str, str]]:
         """
         Génère les remplacements pour les entités spaCy et met à jour l'audit log.
         Retourne le dictionnaire des remplacements (original_text -> anonymized_code)

--- a/anonyfiles_core/anonymizer/replacer.py
+++ b/anonyfiles_core/anonymizer/replacer.py
@@ -1,6 +1,8 @@
-import logging
 import hashlib
-from typing import Any, Callable
+import logging
+from collections.abc import Callable
+from typing import Any
+
 from faker import Faker
 
 from .format_utils import create_placeholder
@@ -78,7 +80,7 @@ def generate_redaction_replacement(
     # Heuristique simple : si finit par "]" ou "}", on insère avant.
     if base_text.startswith("{{") and base_text.endswith("}}"):
         return f"{base_text[:-2]}_{index + 1}" + "}}"
-    if base_text.endswith("]") or base_text.endswith("}"):
+    if base_text.endswith(("]", "}")):
         return f"{base_text[:-1]}_{index + 1}{base_text[-1]}"
     return f"{base_text}_{index + 1}"
 
@@ -94,7 +96,7 @@ def generate_placeholder_replacement(
     """
     Remplace par un format dynamique. Ajoute un index pour l'unicité si non présent.
     """
-    format_str = options.get("format", "{{{}}}".format(label.upper()))
+    format_str = options.get("format", f"{{{label.upper()}}}")
     if "{}" in format_str:
         return format_str.format(entity_text)
 

--- a/anonyfiles_core/anonymizer/run_logger.py
+++ b/anonyfiles_core/anonymizer/run_logger.py
@@ -5,7 +5,7 @@ Module utilitaire pour centraliser le logging des sessions (runs) d'anonymisatio
 Utilisable aussi bien dans le CLI que l'API pour garantir une structure de log cohérente.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 
 def log_run_event(
@@ -15,13 +15,13 @@ def log_run_event(
     output_file: str,
     mapping_file: str,
     log_entities_file: str,
-    entities_detected: Optional[list],
+    entities_detected: list | None,
     total_replacements: int,
-    audit_log: Optional[list],
+    audit_log: list | None,
     status: str,
-    error: Optional[str] = None,
-    command: Optional[str] = None,
-    args: Optional[Dict[str, Any]] = None,
+    error: str | None = None,
+    command: str | None = None,
+    args: dict[str, Any] | None = None,
 ) -> None:
     """
     Log une session (run) d'anonymisation/désanonymisation de façon centralisée et cohérente.

--- a/anonyfiles_core/anonymizer/spacy_engine.py
+++ b/anonyfiles_core/anonymizer/spacy_engine.py
@@ -127,7 +127,7 @@ def _load_spacy_model_cached(model_name: str):
             f"Échec du téléchargement automatique du modèle spaCy '{model_name}' "
             f"(code sortie pip: {exc.code}). {_install_hint(model_name)}"
         ) from exc
-    except Exception as exc:  # noqa: BLE001 - on re-type immédiatement
+    except Exception as exc:
         raise ConfigurationError(
             f"Échec du téléchargement automatique du modèle spaCy '{model_name}': {exc}. "
             f"{_install_hint(model_name)}"
@@ -158,10 +158,7 @@ def is_valid_date(text):
         return False
 
     # Éviter les nombres à virgule ou point isolés (faux positifs fréquents)
-    if re.match(r"^\d+[.,]\d+$", text.strip()):
-        return False
-
-    return True
+    return not re.match(r"^\d+[.,]\d+$", text.strip())
 
 
 class SpaCyEngine:

--- a/anonyfiles_core/anonymizer/spacy_status.py
+++ b/anonyfiles_core/anonymizer/spacy_status.py
@@ -1,14 +1,15 @@
+import contextlib
 import importlib
 import importlib.metadata
 import importlib.resources
 import json
 import platform
-from typing import Any, Dict, Optional
+from typing import Any
 
 DEFAULT_SPACY_MODEL = "fr_core_news_md"
 
 
-def get_spacy_status(model_name: str = DEFAULT_SPACY_MODEL) -> Dict[str, Any]:
+def get_spacy_status(model_name: str = DEFAULT_SPACY_MODEL) -> dict[str, Any]:
     """Return a fast, load-free diagnostic for spaCy and the configured model."""
     model_name = model_name or DEFAULT_SPACY_MODEL
     spacy_version = _distribution_version("spacy")
@@ -20,7 +21,7 @@ def get_spacy_status(model_name: str = DEFAULT_SPACY_MODEL) -> Dict[str, Any]:
     model_version = model_meta.get("version") or model_distribution_version
     spacy_constraint = model_meta.get("spacy_version")
 
-    compatible: Optional[bool] = None
+    compatible: bool | None = None
     if spacy_version and spacy_constraint:
         compatible = _is_compatible_spacy_version(spacy_version, spacy_constraint)
 
@@ -60,7 +61,7 @@ def get_spacy_status(model_name: str = DEFAULT_SPACY_MODEL) -> Dict[str, Any]:
     }
 
 
-def format_spacy_status_for_error(status: Dict[str, Any]) -> str:
+def format_spacy_status_for_error(status: dict[str, Any]) -> str:
     """Build an actionable one-line error message from ``get_spacy_status``."""
     commands = status.get("commands", {})
     model_name = status.get("model", {}).get("name", DEFAULT_SPACY_MODEL)
@@ -74,9 +75,7 @@ def format_spacy_status_for_error(status: Dict[str, Any]) -> str:
     )
 
 
-def _status_message(
-    status: str, model_name: str, spacy_constraint: Optional[str]
-) -> str:
+def _status_message(status: str, model_name: str, spacy_constraint: str | None) -> str:
     if status == "ok":
         return "spaCy et le modele configure sont disponibles."
     if status == "missing_spacy":
@@ -91,7 +90,7 @@ def _status_message(
     return "Diagnostic spaCy indetermine."
 
 
-def _distribution_version(package_name: str) -> Optional[str]:
+def _distribution_version(package_name: str) -> str | None:
     try:
         return importlib.metadata.version(package_name)
     except importlib.metadata.PackageNotFoundError:
@@ -107,7 +106,7 @@ def _find_module(module_name: str) -> bool:
         return False
 
 
-def _read_model_meta(model_name: str) -> Dict[str, Any]:
+def _read_model_meta(model_name: str) -> dict[str, Any]:
     try:
         package_root = importlib.resources.files(model_name)
     except (ImportError, ModuleNotFoundError, AttributeError, TypeError):
@@ -130,8 +129,8 @@ def _read_model_meta(model_name: str) -> Dict[str, Any]:
 
 def _is_compatible_spacy_version(
     spacy_version: str, spacy_constraint: str
-) -> Optional[bool]:
-    try:
+) -> bool | None:
+    with contextlib.suppress(Exception):
         spacy_module = importlib.import_module("spacy")
         is_compatible = getattr(
             getattr(spacy_module, "util", None), "is_compatible_version", None
@@ -140,8 +139,6 @@ def _is_compatible_spacy_version(
             result = is_compatible(spacy_version, spacy_constraint)
             if result is not None:
                 return bool(result)
-    except Exception:
-        pass
 
     try:
         from packaging.specifiers import SpecifierSet

--- a/anonyfiles_core/anonymizer/txt_processor.py
+++ b/anonyfiles_core/anonymizer/txt_processor.py
@@ -1,8 +1,9 @@
 # anonymizer/txt_processor.py
 
+import logging
 from pathlib import Path
 from typing import Any
-import logging
+
 import aiofiles
 
 from .base_processor import BaseProcessor

--- a/anonyfiles_core/anonymizer/utils.py
+++ b/anonyfiles_core/anonymizer/utils.py
@@ -1,13 +1,12 @@
 # anonyfiles_cli/anonymizer/utils.py
 
-from typing import List, Dict, Tuple
 from io import StringIO  # Nécessaire pour la fonction
 
 
 def apply_positional_replacements(
     text: str,
-    entity_replacements: Dict[str, str],
-    entities_in_text_block: List[Tuple[str, str, int, int]],
+    entity_replacements: dict[str, str],
+    entities_in_text_block: list[tuple[str, str, int, int]],
 ) -> str:
     """
     Applique les remplacements d'entités dans un bloc de texte en respectant leurs positions.

--- a/anonyfiles_core/anonymizer/word_processor.py
+++ b/anonyfiles_core/anonymizer/word_processor.py
@@ -1,9 +1,12 @@
 # anonymizer/word_processor.py
 
-from pathlib import Path
 import logging
-from typing import Any, Iterator
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
 from docx import Document
+
 from .base_processor import BaseProcessor
 from .type_defs import TextBlocks
 
@@ -22,7 +25,7 @@ class DocxProcessor(BaseProcessor):
         """Ouvre un document .docx en remontant une erreur claire si illisible."""
         try:
             return Document(str(path))
-        except Exception as exc:  # noqa: BLE001 - on veut un message unifié
+        except Exception as exc:
             raise ValueError(
                 f"Fichier .docx illisible ou corrompu: {Path(path).name} ({exc})"
             ) from exc
@@ -34,8 +37,7 @@ class DocxProcessor(BaseProcessor):
         """
         # 1. Paragraphes directs
         if hasattr(parent_elt, "paragraphs"):
-            for paragraph in parent_elt.paragraphs:
-                yield paragraph
+            yield from parent_elt.paragraphs
 
         # 2. Tableaux (qui contiennent des lignes -> cellules -> paragraphes/tables)
         if hasattr(parent_elt, "tables"):

--- a/anonyfiles_core/anonymizer/writer.py
+++ b/anonyfiles_core/anonymizer/writer.py
@@ -1,10 +1,11 @@
 # anonyfiles_cli/anonymizer/writer.py
 
 import csv
+import io
 from pathlib import Path
 from typing import Any
+
 import aiofiles
-import io
 
 from .base_processor import BaseProcessor
 from .pdf_processor import PdfProcessor  # Spécifique pour kwargs de PDF

--- a/packaging/sidecar/build_sidecar.py
+++ b/packaging/sidecar/build_sidecar.py
@@ -16,6 +16,7 @@ once at install, launches in 2-4 s.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import os
 import shutil
 import subprocess
@@ -24,10 +25,8 @@ from pathlib import Path
 
 # Force UTF-8 stdout so non-ASCII log lines don't crash on Windows cp1252.
 if hasattr(sys.stdout, "reconfigure"):
-    try:
+    with contextlib.suppress(Exception):
         sys.stdout.reconfigure(encoding="utf-8")
-    except Exception:
-        pass
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,10 @@ dependencies = [
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio",
-    # Épinglé pour la même raison que black : ruff 0.16 a élargi son jeu de
-    # règles par défaut (I, SIM, UP, B...), ce qui rendait la CI rouge sur du
-    # code inchangé. Voir la PR de mise à niveau avant de relever ce pin.
-    "ruff==0.15.19",
+    # Épinglé pour la même raison que black : éviter qu'un élargissement des
+    # règles par défaut ne rende la CI rouge sur du code inchangé (c'est ce
+    # qu'a fait 0.16). Relever ce pin volontairement, pas par dérive.
+    "ruff==0.16.0",
     # Épinglé pour un formatage reproductible (évite la dérive de style quand la
     # CI installe une version plus récente). 26.3.1 corrige aussi CVE-2026-32274.
     "black==26.3.1",
@@ -76,6 +76,38 @@ line-length = 88
 [tool.ruff]
 target-version = "py311"
 line-length = 88
+
+[tool.ruff.lint]
+# ruff 0.16 a élargi son jeu de règles par défaut. On garde l'ensemble, sauf
+# les règles qui contredisent les idiomes des frameworks utilisés ici.
+ignore = [
+    # FastAPI et Typer *exigent* l'appel dans les valeurs par défaut :
+    # `= File(...)`, `= Security(...)`, `= typer.Option(...)`. Suivre B008
+    # casserait l'injection de dépendances.
+    "B008",
+    # `except Exception` est délibéré aux frontières CLI/API : on convertit en
+    # message utilisateur et en code de sortie plutôt que de laisser fuiter une
+    # trace. À resserrer progressivement, pas en bloc.
+    "BLE001",
+    # Les timestamps sont volontairement en heure locale : ils servent à nommer
+    # des fichiers de sortie et à afficher des dates à l'utilisateur. Passer en
+    # UTC décalerait les noms de fichiers sans bénéfice ici.
+    "DTZ005",
+    "DTZ006",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Faux positif : le callback est consommé par `compiled_pattern.sub()` dans la
+# même itération, il ne survit jamais à la boucle.
+"anonyfiles_core/anonymizer/custom_rules_processor.py" = ["B023"]
+# `_parse_entity_decisions` lève ValueError pour tout payload malformé, et
+# l'appelant l'attrape pour renvoyer un HTTP 400. Suivre TRY004 ferait remonter
+# un TypeError non capturé, donc un 500.
+"anonyfiles_api/routers/anonymization.py" = ["TRY004"]
+# Les tests ouvrent des fichiers de fixtures dont la durée de vie est celle du
+# test ; le gestionnaire de contexte n'apporte rien. RUF012 sur les doubles de
+# test (`ents = []`) n'apporte rien non plus.
+"tests/**" = ["SIM115", "RUF012"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/scripts/generate_test_logs.py
+++ b/scripts/generate_test_logs.py
@@ -1,7 +1,7 @@
+import argparse
 import random
 import time
 from datetime import datetime, timedelta
-import argparse
 from pathlib import Path
 
 # Constantes pour la simulation

--- a/tests/api/test_anonymization_path_safety.py
+++ b/tests/api/test_anonymization_path_safety.py
@@ -1,16 +1,16 @@
 import pytest
 
 pytest.importorskip("httpx")
+import importlib
 import json
 import shutil
-import importlib
 import sys
 import time
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
-import anonyfiles_api.core_config as core_config
+from anonyfiles_api import core_config
 
 
 def test_anonymize_sanitizes_filenames(tmp_path):
@@ -61,24 +61,26 @@ def test_anonymize_sanitizes_filenames(tmp_path):
             saved["input_path"] = input_path
             Job(job_id).set_status_as_finished_sync({"audit_log": []})
 
-        with patch(
-            "anonyfiles_api.routers.anonymization.run_anonymization_job_sync",
-            side_effect=fake_run_anonymization_job_sync,
+        with (
+            patch(
+                "anonyfiles_api.routers.anonymization.run_anonymization_job_sync",
+                side_effect=fake_run_anonymization_job_sync,
+            ),
+            TestClient(app) as client,
         ):
-            with TestClient(app) as client:
-                files = {"file": ("../secret.txt", b"data")}
-                data = {
-                    "config_options": "{}",
-                    "file_type": "txt",
-                    "has_header": "",
-                    "custom_replacement_rules": "",
-                }
-                resp = client.post("/anonymize/", files=files, data=data)
-                assert resp.status_code == 200
+            files = {"file": ("../secret.txt", b"data")}
+            data = {
+                "config_options": "{}",
+                "file_type": "txt",
+                "has_header": "",
+                "custom_replacement_rules": "",
+            }
+            resp = client.post("/anonymize/", files=files, data=data)
+            assert resp.status_code == 200
 
-                deadline = time.time() + 2
-                while "job_id" not in saved and time.time() < deadline:
-                    time.sleep(0.05)
+            deadline = time.time() + 2
+            while "job_id" not in saved and time.time() < deadline:
+                time.sleep(0.05)
 
         job_id = saved["job_id"]
         job_dir = tmp_path / job_id

--- a/tests/api/test_api_auth.py
+++ b/tests/api/test_api_auth.py
@@ -1,5 +1,5 @@
-from types import SimpleNamespace
 import uuid
+from types import SimpleNamespace
 
 import pytest
 

--- a/tests/api/test_deanonymization_engine.py
+++ b/tests/api/test_deanonymization_engine.py
@@ -1,12 +1,12 @@
 import pytest
 
 pytest.importorskip("aiofiles")
-import shutil
-from unittest.mock import patch
-import sys
-
 import importlib
-import anonyfiles_api.core_config as core_config
+import shutil
+import sys
+from unittest.mock import patch
+
+from anonyfiles_api import core_config
 
 
 def test_run_deanonymization_job_sync_uses_engine(tmp_path):

--- a/tests/api/test_deanonymization_path_safety.py
+++ b/tests/api/test_deanonymization_path_safety.py
@@ -2,14 +2,13 @@ import pytest
 
 pytest.skip("unstable in CI", allow_module_level=True)
 pytest.importorskip("httpx")
-import shutil  # noqa: E402
-from unittest.mock import patch  # noqa: E402
+import importlib
+import shutil
+from unittest.mock import patch
 
-from fastapi.testclient import TestClient  # noqa: E402
+from fastapi.testclient import TestClient
 
-import importlib  # noqa: E402
-
-import anonyfiles_api.core_config as core_config  # noqa: E402
+from anonyfiles_api import core_config
 
 
 def test_deanonymize_sanitizes_filenames(tmp_path):

--- a/tests/api/test_deanonymization_streaming.py
+++ b/tests/api/test_deanonymization_streaming.py
@@ -2,15 +2,15 @@ import pytest
 
 pytest.skip("unstable in CI", allow_module_level=True)
 pytest.importorskip("httpx")
-import shutil  # noqa: E402
-import importlib  # noqa: E402
-import sys  # noqa: E402
-from unittest.mock import patch  # noqa: E402
+import importlib
+import shutil
+import sys
+from unittest.mock import patch
 
-import fastapi  # noqa: E402
-from fastapi.testclient import TestClient  # noqa: E402
+import fastapi
+from fastapi.testclient import TestClient
 
-import anonyfiles_api.core_config as core_config  # noqa: E402
+from anonyfiles_api import core_config
 
 
 def test_deanonymize_uses_streaming(tmp_path):

--- a/tests/api/test_job_queue.py
+++ b/tests/api/test_job_queue.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 
-import anonyfiles_api.core_config as core_config
+from anonyfiles_api import core_config
 from anonyfiles_api.job_queue import JobQueue
 from anonyfiles_api.job_utils import Job
 

--- a/tests/api/test_jobs_api.py
+++ b/tests/api/test_jobs_api.py
@@ -8,7 +8,7 @@ import pytest
 pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
 
-import anonyfiles_api.core_config as core_config
+from anonyfiles_api import core_config
 from anonyfiles_api.job_utils import Job
 
 

--- a/tests/api/test_websocket_status.py
+++ b/tests/api/test_websocket_status.py
@@ -1,6 +1,6 @@
-import time
 import importlib
 import sys
+import time
 from unittest.mock import patch
 
 import pytest
@@ -8,7 +8,7 @@ import pytest
 pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
 
-import anonyfiles_api.core_config as core_config
+from anonyfiles_api import core_config
 from anonyfiles_api.job_utils import Job
 
 
@@ -50,37 +50,39 @@ def test_websocket_reports_status_progress(tmp_path):
             time.sleep(1.5)
             Job(job_id).set_status_as_finished_sync({"audit_log": []})
 
-        with patch(
-            "anonyfiles_api.routers.anonymization.run_anonymization_job_sync",
-            side_effect=fake_run_anonymization_job_sync,
+        with (
+            patch(
+                "anonyfiles_api.routers.anonymization.run_anonymization_job_sync",
+                side_effect=fake_run_anonymization_job_sync,
+            ),
+            TestClient(app) as client,
         ):
-            with TestClient(app) as client:
-                files = {"file": ("input.txt", b"data")}
-                data = {
-                    "config_options": "{}",
-                    "file_type": "txt",
-                    "has_header": "",
-                    "custom_replacement_rules": "",
-                }
-                resp = client.post("/anonymize/", files=files, data=data)
-                assert resp.status_code == 200
-                job_id = resp.json()["job_id"]
+            files = {"file": ("input.txt", b"data")}
+            data = {
+                "config_options": "{}",
+                "file_type": "txt",
+                "has_header": "",
+                "custom_replacement_rules": "",
+            }
+            resp = client.post("/anonymize/", files=files, data=data)
+            assert resp.status_code == 200
+            job_id = resp.json()["job_id"]
 
-                with client.websocket_connect(f"/ws/{job_id}") as ws:
-                    payloads = [ws.receive_json()]
-                    while payloads[-1]["status"] not in {
-                        "finished",
-                        "error",
-                        "cancelled",
-                        "timeout",
-                    }:
-                        payloads.append(ws.receive_json())
-                    assert payloads[0]["status"] == "pending"
-                    assert payloads[-1]["status"] in {
-                        "finished",
-                        "error",
-                        "cancelled",
-                        "timeout",
-                    }
+            with client.websocket_connect(f"/ws/{job_id}") as ws:
+                payloads = [ws.receive_json()]
+                while payloads[-1]["status"] not in {
+                    "finished",
+                    "error",
+                    "cancelled",
+                    "timeout",
+                }:
+                    payloads.append(ws.receive_json())
+                assert payloads[0]["status"] == "pending"
+                assert payloads[-1]["status"] in {
+                    "finished",
+                    "error",
+                    "cancelled",
+                    "timeout",
+                }
     finally:
         core_config.JOBS_DIR = original_jobs_dir

--- a/tests/cli/gen_samples.py
+++ b/tests/cli/gen_samples.py
@@ -1,9 +1,10 @@
 # tests/gen_samples_adv.py
 
-from faker import Faker
-from pathlib import Path
 import csv
 import json
+from pathlib import Path
+
+from faker import Faker
 
 try:
     from docx import Document

--- a/tests/cli/generate_test_pdf.py
+++ b/tests/cli/generate_test_pdf.py
@@ -1,4 +1,5 @@
 import os
+
 from reportlab.lib.pagesizes import A4
 from reportlab.pdfgen import canvas
 
@@ -9,7 +10,7 @@ def create_test_pdf(path):
     os.makedirs(os.path.dirname(path), exist_ok=True)
 
     c = canvas.Canvas(path, pagesize=A4)
-    width, height = A4
+    _width, height = A4
 
     # Page 1
     c.drawString(100, height - 100, "Bonjour Pierre Dupont, vous habitez à Paris.")

--- a/tests/cli/test_cli_e2e.py
+++ b/tests/cli/test_cli_e2e.py
@@ -1,16 +1,17 @@
 import pytest
 
 pytest.importorskip("typer")
-from typer.testing import CliRunner  # noqa: E402
-from pathlib import Path  # noqa: E402
-from types import SimpleNamespace  # noqa: E402
-from unittest.mock import patch  # noqa: E402
-import zipfile  # noqa: E402
-import json  # noqa: E402
+import json
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
-from anonyfiles_cli.main import app  # noqa: E402
-from anonyfiles_core.anonymizer import spacy_engine  # noqa: E402
-from anonyfiles_cli.managers.config_manager import ConfigManager  # noqa: E402
+from typer.testing import CliRunner
+
+from anonyfiles_cli.main import app
+from anonyfiles_cli.managers.config_manager import ConfigManager
+from anonyfiles_core.anonymizer import spacy_engine
 
 
 class DummyRuler:
@@ -255,7 +256,7 @@ def test_cli_verbose_outputs_debug():
     runner = CliRunner()
     result = runner.invoke(app, ["--verbose", "config", "validate-config", str(cfg)])
     assert result.exit_code == 0
-    assert "DEBUG:root:Verbose mode enabled" in result.output
+    assert "DEBUG:anonyfiles_cli.main:Verbose mode enabled" in result.output
 
 
 def test_cli_missing_spacy_model(tmp_path):

--- a/tests/cli/test_csv_processor.py
+++ b/tests/cli/test_csv_processor.py
@@ -1,8 +1,8 @@
 import pytest
 
 pytest.importorskip("spacy")
-import tempfile
 import csv
+import tempfile
 from pathlib import Path
 
 from anonyfiles_core.anonymizer.csv_processor import CsvProcessor

--- a/tests/cli/test_docx_processor.py
+++ b/tests/cli/test_docx_processor.py
@@ -1,9 +1,10 @@
 import pytest
 
 Document = pytest.importorskip("docx").Document
-from anonyfiles_core.anonymizer.word_processor import DocxProcessor  # noqa: E402
-from pathlib import Path  # noqa: E402
-import tempfile  # noqa: E402
+import tempfile
+from pathlib import Path
+
+from anonyfiles_core.anonymizer.word_processor import DocxProcessor
 
 
 def test_extract_blocks_docx():

--- a/tests/cli/test_excel_processor.py
+++ b/tests/cli/test_excel_processor.py
@@ -1,9 +1,10 @@
 import pytest
 
 pd = pytest.importorskip("pandas")
-import tempfile  # noqa: E402
-from anonyfiles_core.anonymizer.excel_processor import ExcelProcessor  # noqa: E402
-from pathlib import Path  # noqa: E402
+import tempfile
+from pathlib import Path
+
+from anonyfiles_core.anonymizer.excel_processor import ExcelProcessor
 
 
 def test_extract_blocks_excel():

--- a/tests/cli/test_job_cli.py
+++ b/tests/cli/test_job_cli.py
@@ -1,9 +1,10 @@
 import pytest
 
 pytest.importorskip("typer")
-from typer.testing import CliRunner
-import types
 import sys
+import types
+
+from typer.testing import CliRunner
 
 # Stub heavy dependencies used during CLI import with minimal attributes.
 # NB: spaCy n'est PAS stubbé — un stub partiel masquerait `spacy.util` et casserait
@@ -15,7 +16,7 @@ sys.modules.setdefault("docx", fake_docx)
 sys.modules.setdefault("pandas", types.ModuleType("pandas"))
 sys.modules.setdefault("fitz", types.ModuleType("fitz"))
 
-from anonyfiles_cli.main import app  # noqa: E402
+from anonyfiles_cli.main import app
 
 
 def test_job_list_nonexistent_directory(tmp_path):

--- a/tests/cli/test_json_processor.py
+++ b/tests/cli/test_json_processor.py
@@ -1,10 +1,11 @@
 import pytest
 
 pytest.importorskip("spacy")
-import tempfile
-from anonyfiles_core.anonymizer.json_processor import JsonProcessor
-from pathlib import Path
 import json
+import tempfile
+from pathlib import Path
+
+from anonyfiles_core.anonymizer.json_processor import JsonProcessor
 
 
 def _nested_sample() -> str:

--- a/tests/cli/test_pdf_processor.py
+++ b/tests/cli/test_pdf_processor.py
@@ -1,10 +1,10 @@
 import pytest
 
 fitz = pytest.importorskip("fitz")
-import tempfile  # noqa: E402
-from pathlib import Path  # noqa: E402
+import tempfile
+from pathlib import Path
 
-from anonyfiles_core.anonymizer.pdf_processor import PdfProcessor  # noqa: E402
+from anonyfiles_core.anonymizer.pdf_processor import PdfProcessor
 
 
 def create_simple_pdf(path: Path, text: str) -> None:

--- a/tests/cli/test_txt_processor.py
+++ b/tests/cli/test_txt_processor.py
@@ -2,8 +2,9 @@ import pytest
 
 pytest.importorskip("spacy")
 import tempfile
-from anonyfiles_core.anonymizer.txt_processor import TxtProcessor
 from pathlib import Path
+
+from anonyfiles_core.anonymizer.txt_processor import TxtProcessor
 
 
 def test_extract_blocks_simple():

--- a/tests/e2e/test_full_flow.py
+++ b/tests/e2e/test_full_flow.py
@@ -1,7 +1,9 @@
-import pytest
 import shutil
 from pathlib import Path
+
+import pytest
 from pypdf import PdfReader
+
 from anonyfiles_core import AnonyfilesEngine
 
 # Chemin des ressources de test

--- a/tests/manual/test_complex_run.py
+++ b/tests/manual/test_complex_run.py
@@ -1,6 +1,7 @@
 import logging
 import shutil
 from pathlib import Path
+
 from anonyfiles_core import AnonyfilesEngine
 
 # Configure logging
@@ -65,8 +66,8 @@ def run_test():
                 mapping_dict[row[0]] = row[1]
 
     print("--- MAPPING KEYS DETECTED ---")
-    for k in mapping_dict.keys():
-        print(f"Key: '{k}' -> '{mapping_dict[k]}'")
+    for k, v in mapping_dict.items():
+        print(f"Key: '{k}' -> '{v}'")
     print("----------------------------")
 
     # Check specific uniqueness cases based on input text

--- a/tests/unit/test_console_display.py
+++ b/tests/unit/test_console_display.py
@@ -1,6 +1,7 @@
 import pytest
-from anonyfiles_cli.ui.console_display import ConsoleDisplay
+
 from anonyfiles_cli.exceptions import ConfigurationError, FileIOError, ProcessingError
+from anonyfiles_cli.ui.console_display import ConsoleDisplay
 
 
 class DummyLogger:

--- a/tests/unit/test_privacy_warning_scanner.py
+++ b/tests/unit/test_privacy_warning_scanner.py
@@ -7,10 +7,12 @@ from anonyfiles_core.anonymizer.privacy_warning_scanner import (
 def test_scanner_reports_suspicious_values_by_category():
     warnings = scan_blocks_for_privacy_warnings(
         [
-            "Pierre contacte ambre [at] exemple [dot] fr.\n"
-            "Tel: +33 (0)6 12 34 56 78\n"
-            "Adresse: 12 rue Victor Hugo 75015 Paris\n"
-            "KMCL\n"
+            (
+                "Pierre contacte ambre [at] exemple [dot] fr.\n"
+                "Tel: +33 (0)6 12 34 56 78\n"
+                "Adresse: 12 rue Victor Hugo 75015 Paris\n"
+                "KMCL\n"
+            )
         ],
         enabled_labels={"PER", "EMAIL", "PHONE", "ADDRESS", "ORG", "MISC"},
     )
@@ -26,7 +28,7 @@ def test_scanner_reports_suspicious_values_by_category():
 
 def test_scanner_ignores_generated_placeholders_and_replacements():
     warnings = scan_blocks_for_privacy_warnings(
-        ["{{NOM_001}} [ENTREPRISE_ANONYME_1] Jean Martin " "contact@example.com"],
+        ["{{NOM_001}} [ENTREPRISE_ANONYME_1] Jean Martin contact@example.com"],
         enabled_labels={"PER", "EMAIL", "ORG", "MISC"},
         ignored_values={"Jean Martin", "contact@example.com"},
     )

--- a/tests/unit/test_spacy_engine.py
+++ b/tests/unit/test_spacy_engine.py
@@ -4,8 +4,8 @@ pytest.importorskip("spacy")
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from anonyfiles_core.anonymizer import spacy_engine
 from anonyfiles_cli.exceptions import ConfigurationError
+from anonyfiles_core.anonymizer import spacy_engine
 
 
 class DummyRuler:
@@ -73,8 +73,10 @@ def test_load_model_failure_raises_configuration_error():
     def fail_load(name, **kwargs):
         raise OSError("model missing")
 
-    with patch.object(spacy_engine, "spacy", _fake_spacy(fail_load)):
-        with pytest.raises(ConfigurationError) as exc:
-            spacy_engine.SpaCyEngine(model="missing")
+    with (
+        patch.object(spacy_engine, "spacy", _fake_spacy(fail_load)),
+        pytest.raises(ConfigurationError) as exc,
+    ):
+        spacy_engine.SpaCyEngine(model="missing")
     msg = str(exc.value)
     assert "python -m spacy download missing" in msg


### PR DESCRIPTION
## Contexte

`main` a été débloqué en épinglant `ruff==0.15.19` (commit `fc08edb`), parce que la CI installait ruff 0.16 dont le jeu de règles par défaut s'est élargi (`I`, `SIM`, `UP`, `B`, `TRY`, `G`, `RUF`...) : **599 erreurs sur 86 fichiers inchangés**.

Cette PR fait l'inverse du contournement : elle adopte ruff 0.16 et ses règles, puis relève le pin.

## Ce qui a été fait

**471 corrections automatiques** (`ruff check --fix`) : tri des imports, `Optional[X]` → `X | None`, `List`/`Dict` → `list`/`dict`, `timezone.utc` → `datetime.UTC`, suppression de `noqa` devenus obsolètes.

**Corrections manuelles**, par famille :

| Règle | Correction |
|---|---|
| `G201` / `TRY401` | `logger.error(..., exc_info=True)` → `logger.exception(...)`, sans réinterpoler l'exception que le handler joint déjà |
| `LOG014` | `exc_info=` en dehors d'un gestionnaire d'exception |
| `LOG015` | `logging.debug()` sur le root logger → logger de module |
| `S110` | `try/except/pass` → `contextlib.suppress` (strictement équivalent) |
| `PIE810` | `endswith(a) or endswith(b)` → `endswith((a, b))` |
| divers | `SIM103`, `SIM117`, `UP028`, `C414`, `ISC004`, `PLC0206`, `PLW1508`, `TRY201`, `RUF012`, `RUF059` |

Un test a dû être ajusté : `test_cli_verbose_outputs_debug` assertait le préfixe `DEBUG:root:`, qui devient `DEBUG:anonyfiles_cli.main:` une fois `LOG015` corrigé. C'est le comportement attendu, pas un contournement.

## Règles écartées

Chacune est justifiée par un commentaire dans `pyproject.toml`, pas ignorée en silence :

- **`B008`** — FastAPI et Typer *exigent* l'appel dans les valeurs par défaut (`= File(...)`, `= Security(...)`, `= typer.Option(...)`). Suivre la règle casserait l'injection de dépendances.
- **`BLE001`** — `except Exception` est délibéré aux frontières CLI/API : on convertit en message utilisateur et code de sortie. À resserrer progressivement, pas en bloc.
- **`DTZ005` / `DTZ006`** — les timestamps sont volontairement en heure locale : ils nomment des fichiers de sortie et s'affichent à l'utilisateur. Passer en UTC décalerait les noms de fichiers sans bénéfice.
- **`TRY004`** (`routers/anonymization.py`) — `_parse_entity_decisions` lève `ValueError` pour tout payload malformé, et l'appelant l'attrape pour renvoyer un **400**. Suivre la règle ferait remonter un `TypeError` non capturé, donc un **500**.
- **`SIM115` / `RUF012`** (tests) — bruit sur les fixtures et les doubles de test.
- **`B023`** (`custom_rules_processor.py`) — faux positif : le callback est consommé par `compiled_pattern.sub()` dans la même itération, il ne survit jamais à la boucle.

## Vérification

- `ruff check .` (0.16.0) : clean
- `black --check .` : clean
- `mypy` : clean
- `pytest` : 118 passed, 2 skipped
- CLI et API démarrent, anonymisation de bout en bout vérifiée sur un fichier réel

## Note

L'échec `pip-audit` mentionné initialement (`setuptools 79.0.1`, `PYSEC-2026-3447`) a été corrigé séparément sur `main` en `e999718` et la branche a été rebasée dessus. La CI est verte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
