### PR TITLE
fix(core): anonymiser le texte des zones de texte .docx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Le format suit [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/) et la ge
 
 ---
 
+## [Non publié]
+
+### Corrigé
+- **Le texte des zones de texte (`.docx`) n'était pas anonymisé.** python-docx n'expose que les paragraphes enfants directs du corps, des cellules de tableau et des en-têtes/pieds ; le contenu d'une zone de texte vit dans un `w:txbxContent` imbriqué sous `w:pict` (VML) ou `wps:txbx` (DrawingML) et échappait donc entièrement au moteur — les noms, adresses et emails placés dans une zone de texte ressortaient en clair. Le parcours du `DocxProcessor` descend désormais dans les zones de texte, y compris celles des en-têtes/pieds, celles imbriquées et les tableaux qu'elles contiennent. Les deux copies d'un `mc:AlternateContent` (`mc:Choice` + `mc:Fallback`) sont traitées, sinon la copie de repli conservait le texte d'origine dans le fichier livré (issue #78).
+
 ## [1.6.0] – 2026-06-25
 
 ### Modifié

--- a/anonyfiles_core/anonymizer/word_processor.py
+++ b/anonyfiles_core/anonymizer/word_processor.py
@@ -6,17 +6,25 @@ from pathlib import Path
 from typing import Any
 
 from docx import Document
+from docx.oxml.ns import qn
+from docx.text.paragraph import Paragraph
 
 from .base_processor import BaseProcessor
 from .type_defs import TextBlocks
 
 logger = logging.getLogger(__name__)
 
+# Conteneur du texte d'une zone de texte, quelle que soit la techno utilisée par
+# Word : VML (`w:pict/v:shape/v:textbox`) ou DrawingML (`w:drawing/wps:txbx`).
+_TXBX_CONTENT = qn("w:txbxContent")
+_PARAGRAPH = qn("w:p")
+
 
 class DocxProcessor(BaseProcessor):
     """
     Processor pour les fichiers .docx.
-    - Traverse hiérarchiquement : Paragraphes du corps -> Tableaux (récursifs).
+    - Traverse hiérarchiquement : Paragraphes du corps -> Tableaux (récursifs)
+      -> Zones de texte.
     - Préserve l'intégrité de la structure tout en anonymisant l'ensemble du contenu.
     """
 
@@ -47,6 +55,47 @@ class DocxProcessor(BaseProcessor):
                         # Récursion: une cellule contient des paragraphes et potentiellement d'autres tables
                         yield from self._iter_block_items(cell)
 
+    @staticmethod
+    def _is_inside_textbox(p_elt: Any) -> bool:
+        """Indique si un ``w:p`` est le contenu d'une zone de texte."""
+        parent = p_elt.getparent()
+        while parent is not None:
+            if parent.tag == _TXBX_CONTENT:
+                return True
+            parent = parent.getparent()
+        return False
+
+    def _iter_textbox_paragraphs(self, container: Any, root_elt: Any) -> Iterator[Any]:
+        """
+        Itère sur les paragraphes des zones de texte, que python-docx ignore.
+
+        python-docx n'expose que les ``w:p`` enfants directs du corps, des
+        cellules de tableau et des en-têtes/pieds. Le texte d'une zone de texte
+        vit dans un ``w:txbxContent`` imbriqué sous ``w:pict`` (VML) ou
+        ``wps:txbx`` (DrawingML) : il échappait donc entièrement à
+        l'anonymisation (issue #78).
+
+        Word duplique fréquemment une même zone de texte dans un
+        ``mc:AlternateContent`` (``mc:Choice`` DrawingML + ``mc:Fallback``
+        VML). Les deux copies sont renvoyées : n'en traiter qu'une laisserait
+        le texte d'origine en clair dans le fichier livré.
+
+        Le filtrage par ancêtre ``w:txbxContent`` garantit que ce parcours est
+        disjoint de ``_iter_block_items`` (qui ne descend jamais dans
+        ``w:pict``/``w:drawing``), y compris pour les zones de texte imbriquées
+        et les tableaux placés dans une zone de texte.
+        """
+        for p_elt in root_elt.iter(_PARAGRAPH):
+            if self._is_inside_textbox(p_elt):
+                yield Paragraph(p_elt, container)
+
+    def _iter_container_paragraphs(
+        self, container: Any, root_elt: Any
+    ) -> Iterator[Any]:
+        """Paragraphes d'un conteneur : blocs standards puis zones de texte."""
+        yield from self._iter_block_items(container)
+        yield from self._iter_textbox_paragraphs(container, root_elt)
+
     def _iter_header_footer_parts(self, doc: Any) -> Iterator[Any]:
         """
         Itère sur les en-têtes et pieds de page *propres* à chaque section.
@@ -73,14 +122,15 @@ class DocxProcessor(BaseProcessor):
     def _iter_document_paragraphs(self, doc: Any) -> Iterator[Any]:
         """
         Ordre déterministe couvrant TOUT le texte anonymisable d'un document :
-        corps (paragraphes + tableaux), puis en-têtes et pieds de page.
+        corps (paragraphes + tableaux + zones de texte), puis en-têtes et pieds
+        de page (mêmes règles).
 
         ``extract_blocks`` et ``reconstruct_and_write_anonymized_file`` partagent
         ce parcours pour garantir l'alignement index-par-index des blocs.
         """
-        yield from self._iter_block_items(doc)
+        yield from self._iter_container_paragraphs(doc, doc.element.body)
         for part in self._iter_header_footer_parts(doc):
-            yield from self._iter_block_items(part)
+            yield from self._iter_container_paragraphs(part, part._element)
 
     def extract_blocks(self, input_path: Path, **kwargs: Any) -> TextBlocks:
         """

--- a/tests/unit/test_word_textbox_extraction.py
+++ b/tests/unit/test_word_textbox_extraction.py
@@ -1,0 +1,168 @@
+"""Zones de texte .docx — issue #78.
+
+python-docx n'expose que les ``w:p`` enfants directs du corps, des cellules de
+tableau et des en-têtes/pieds. Le texte d'une zone de texte vit dans un
+``w:txbxContent`` imbriqué : il échappait entièrement à l'anonymisation.
+"""
+
+import pytest
+
+pytest.importorskip("docx")
+
+from docx import Document
+from docx.oxml.ns import nsmap, qn
+from docx.oxml.parser import parse_xml
+
+from anonyfiles_core.anonymizer.word_processor import DocxProcessor
+
+_NS = " ".join(f'xmlns:{prefix}="{uri}"' for prefix, uri in nsmap.items())
+
+# Zone de texte VML (`w:pict`), la forme héritée toujours produite par Word.
+VML_TEXTBOX = f"""
+<w:p {_NS} xmlns:v="urn:schemas-microsoft-com:vml">
+  <w:r>
+    <w:pict>
+      <v:shape style="width:200pt;height:50pt">
+        <v:textbox>
+          <w:txbxContent>
+            <w:p><w:r><w:t>{{text}}</w:t></w:r></w:p>
+          </w:txbxContent>
+        </v:textbox>
+      </v:shape>
+    </w:pict>
+  </w:r>
+</w:p>
+"""
+
+# Zone de texte DrawingML enveloppée dans un `mc:AlternateContent` : Word y
+# duplique le contenu (Choice moderne + Fallback VML). Les DEUX copies doivent
+# être anonymisées, sinon le repli conserve le texte d'origine en clair.
+DRAWINGML_TEXTBOX = f"""
+<w:p {_NS}
+     xmlns:v="urn:schemas-microsoft-com:vml"
+     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+     xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+  <w:r>
+    <mc:AlternateContent>
+      <mc:Choice Requires="wps">
+        <w:drawing>
+          <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+            <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <a:graphicData>
+                <wps:wsp>
+                  <wps:txbx>
+                    <w:txbxContent>
+                      <w:p><w:r><w:t>{{text}}</w:t></w:r></w:p>
+                    </w:txbxContent>
+                  </wps:txbx>
+                </wps:wsp>
+              </a:graphicData>
+            </a:graphic>
+          </wp:inline>
+        </w:drawing>
+      </mc:Choice>
+      <mc:Fallback>
+        <w:pict>
+          <v:shape style="width:200pt;height:50pt">
+            <v:textbox>
+              <w:txbxContent>
+                <w:p><w:r><w:t>{{text}}</w:t></w:r></w:p>
+              </w:txbxContent>
+            </v:textbox>
+          </v:shape>
+        </w:pict>
+      </mc:Fallback>
+    </mc:AlternateContent>
+  </w:r>
+</w:p>
+"""
+
+
+def _append_xml(container_element, xml: str, text: str) -> None:
+    container_element.append(parse_xml(xml.format(text=text).strip()))
+
+
+def _build_docx(tmp_path, *, header_textbox: bool = False):
+    doc = Document()
+    doc.add_paragraph("Le corps mentionne Jean Dupont.")
+    table = doc.add_table(rows=1, cols=1)
+    table.cell(0, 0).paragraphs[0].text = "La cellule mentionne Marie Curie."
+    _append_xml(doc.element.body, VML_TEXTBOX, "La zone VML mentionne Paul Valery.")
+    _append_xml(
+        doc.element.body, DRAWINGML_TEXTBOX, "La zone DrawingML mentionne Alan Turing."
+    )
+    if header_textbox:
+        header = doc.sections[0].header
+        header.is_linked_to_previous = False
+        _append_xml(header._element, VML_TEXTBOX, "L'en-tete mentionne Ada Lovelace.")
+
+    path = tmp_path / "avec_zones_de_texte.docx"
+    doc.save(path)
+    return path
+
+
+def test_textbox_text_is_extracted(tmp_path):
+    path = _build_docx(tmp_path)
+    blocks = DocxProcessor().extract_blocks(path)
+
+    assert "La zone VML mentionne Paul Valery." in blocks
+    # Choice + Fallback : le contenu apparaît deux fois, et les deux doivent
+    # être traités pour ne pas laisser de texte en clair dans le repli.
+    assert blocks.count("La zone DrawingML mentionne Alan Turing.") == 2
+    # Le contenu déjà géré n'est pas dupliqué par le nouveau parcours.
+    assert blocks.count("Le corps mentionne Jean Dupont.") == 1
+    assert blocks.count("La cellule mentionne Marie Curie.") == 1
+
+
+def test_textbox_in_header_is_extracted(tmp_path):
+    path = _build_docx(tmp_path, header_textbox=True)
+    blocks = DocxProcessor().extract_blocks(path)
+
+    assert "L'en-tete mentionne Ada Lovelace." in blocks
+
+
+def test_textbox_text_is_rewritten_in_output(tmp_path):
+    """Le tour complet : extraction -> substitution -> réécriture du .docx."""
+    path = _build_docx(tmp_path)
+    processor = DocxProcessor()
+    blocks = processor.extract_blocks(path)
+
+    anonymised = [block.replace("Alan Turing", "PER_1") for block in blocks]
+    anonymised = [block.replace("Paul Valery", "PER_2") for block in anonymised]
+
+    output = tmp_path / "sortie.docx"
+    processor.reconstruct_and_write_anonymized_file(output, anonymised, path)
+
+    reread = processor.extract_blocks(output)
+    assert "La zone VML mentionne PER_2." in reread
+    assert reread.count("La zone DrawingML mentionne PER_1.") == 2
+
+    # Aucune trace du texte d'origine où que ce soit dans le XML livré.
+    rewritten = Document(str(output))
+    full_xml = rewritten.element.xml
+    assert "Alan Turing" not in full_xml
+    assert "Paul Valery" not in full_xml
+
+
+def test_document_without_textbox_is_unaffected(tmp_path):
+    doc = Document()
+    doc.add_paragraph("Un simple paragraphe.")
+    path = tmp_path / "simple.docx"
+    doc.save(path)
+
+    assert DocxProcessor().extract_blocks(path) == ["Un simple paragraphe."]
+
+
+def test_paragraph_lookup_ignores_non_textbox_nesting(tmp_path):
+    """Un `w:p` du corps n'est jamais confondu avec du contenu de zone de texte."""
+    doc = Document()
+    paragraph = doc.add_paragraph("Corps.")
+    assert DocxProcessor._is_inside_textbox(paragraph._p) is False
+
+    _append_xml(doc.element.body, VML_TEXTBOX, "Dans la zone.")
+    textbox_p = [
+        p
+        for p in doc.element.body.iter(qn("w:p"))
+        if DocxProcessor._is_inside_textbox(p)
+    ]
+    assert len(textbox_p) == 1


### PR DESCRIPTION
Corrige #78 — le texte contenu dans les zones de texte d'un `.docx` n'était pas anonymisé.

Le diagnostic du rapporteur est exact, avec une conséquence à souligner : ce n'était pas une simple omission d'extraction, mais **une fuite de données**. Un nom, une adresse ou un email placé dans une zone de texte ressortait en clair dans le fichier « anonymisé ».

## Cause

Deux limites de `python-docx` se combinent :

1. `_iter_block_items` ne voit que les `w:p` enfants directs du corps, des cellules de tableau et des en-têtes/pieds. Le texte d'une zone de texte vit dans un `w:txbxContent` imbriqué sous `w:pict` (VML) ou `wps:txbx` (DrawingML).
2. `CT_R.text` ne concatène que les `w:t` **enfants directs** du run (`xpath("w:br | w:cr | w:noBreakHyphen | w:ptab | w:t | w:tab")`), donc le paragraphe d'ancrage ne « rattrape » pas non plus ce texte.

Résultat : le contenu des zones de texte était totalement invisible pour le moteur, en extraction comme en réécriture.

## Correctif

`DocxProcessor` sélectionne désormais aussi les `w:p` ayant un ancêtre `w:txbxContent`, dans le corps comme dans les en-têtes/pieds.

Ce filtre par ancêtre est **disjoint par construction** de `_iter_block_items` (qui ne descend jamais dans `w:pict`/`w:drawing`) : pas de dédoublonnage par identité d'élément nécessaire, tout en couvrant les zones de texte imbriquées et les tableaux placés dans une zone de texte.

Point important : Word duplique fréquemment une zone de texte dans un `mc:AlternateContent` (`mc:Choice` DrawingML + `mc:Fallback` VML). **Les deux copies sont traitées** — n'en anonymiser qu'une laisserait le texte d'origine en clair dans le repli du fichier livré. C'est pour cela qu'un test attend délibérément un `count(...) == 2`.

L'alignement index-par-index entre extraction et reconstruction reste garanti : les deux partagent `_iter_document_paragraphs`, et le contrôle de cohérence existant (`Mismatch Reconstruct Word`) est inchangé.

## Tests

`tests/unit/test_word_textbox_extraction.py`, à partir de vrais fragments OOXML injectés dans un document :

- extraction d'une zone de texte VML et d'une zone DrawingML (`mc:AlternateContent` complet) ;
- zone de texte dans un en-tête ;
- tour complet extraction → substitution → réécriture, avec vérification qu'**aucune trace du texte d'origine ne subsiste dans le XML livré** ;
- non-régression : document sans zone de texte inchangé, et contenu déjà géré (corps, tableau) non dupliqué par le nouveau parcours.

Sans le correctif, 4 de ces 5 tests échouent (vérifié en réappliquant l'ancien `word_processor.py`).

Vérifications locales : `pytest tests/unit` (50 passed), `mypy` (clean — `word_processor.py` fait partie des fichiers typés), `ruff` + `black` (clean).

## Portée

Cette PR est indépendante de #77 (sauvegarde macOS) et part de `main` ; les deux peuvent être mergées dans n'importe quel ordre.

À noter, hors périmètre : les mêmes zones de texte sont invisibles pour d'autres conteneurs que `python-docx` ignore (contenu de `w:sdt`, notes de bas de page). Je ne les ai pas touchés ici pour garder la PR ciblée sur l'issue, mais ils méritent probablement une issue de suivi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZ4rb9J6Ceg8UyHwtnQpiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZ4rb9J6Ceg8UyHwtnQpiF)_