### PR TITLE
chore(release): 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Le format suit [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/) et la ge
 
 ---
 
-## [Non publié]
+## [1.6.1] – 2026-08-20
 
 ### Corrigé
 - **GUI : « Anonymiser » ne produisait aucun résultat visible pour les formats binaires** (`.docx`, `.pdf`, `.xlsx`). L'API lisait le fichier de sortie en UTF-8 ; l'échec de décodage vidait `anonymized_text` et le panneau de résultat restait masqué, sans message d'erreur. L'API renvoie désormais `output_file_name` + `output_is_binary`, et la GUI affiche le panneau avec un bouton **« Télécharger le fichier »** (issue #76).


### PR DESCRIPTION
Fige la section « Non publié » du CHANGELOG en `1.6.1`, en préparation du tag `v1.6.1`.

## Contenu de la version

Deux correctifs déjà mergés, tous deux sous `### Corrigé` :

- **#77** (issue #76) — sortie binaire récupérable + export réparé sous macOS ;
- **#79** (issue #78) — texte des zones de texte `.docx` anonymisé.

## Choix du numéro

`1.6.0 → 1.6.1` : bump de **patch**, les deux changements étant des corrections de bugs. C'est cohérent avec le précédent `1.4.2` du dépôt (correctif macOS du sidecar, livré en patch).

Un argument existait pour un minor — l'API a gagné deux champs de réponse (`output_file_name`, `output_is_binary`) et la GUI un bouton — mais ces ajouts n'existent que pour rendre les correctifs possibles, et `1.4.3` avait déjà livré du support de formats en patch.

À noter : le tag `v1.6.0` n'a jamais été créé (tags existants : `v1.4.2`, `v1.5.0`). Le dépôt passera donc de `v1.5.0` à `v1.6.1`, sans conséquence — `desktop-build.yml` ne lit que le tag courant via `GITHUB_REF_NAME`.

## Diff

Une ligne : `## [Non publié]` → `## [1.6.1] – 2026-08-20`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZ4rb9J6Ceg8UyHwtnQpiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZ4rb9J6Ceg8UyHwtnQpiF)_