### PR TITLE
fix(ci): publier les binaires desktop malgré les releases immuables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,36 +187,21 @@ jobs:
           cache-to: type=gha,mode=max
 
   # -------------------------------------------------------------
-  # 4. GITHUB RELEASE
-  #    Crée une release officielle et y attache les wheels.
+  # 4. GITHUB RELEASE — volontairement absent de ce workflow.
+  #
+  #    ci.yml et desktop-build.yml se déclenchent tous deux sur les tags
+  #    'v*'. Tant que deux jobs appelaient action-gh-release sur la même
+  #    release, ils étaient en course. Depuis l'activation des releases
+  #    immuables, le perdant échoue : la publication verrouille la release
+  #    et tout upload ultérieur est rejeté avec
+  #    « Cannot upload asset to an immutable release ».
+  #
+  #    C'est ce qui est arrivé en v1.6.1 : ci.yml a publié les wheels en
+  #    premier, et les six binaires desktop ont été refusés — la release
+  #    annonçait des fichiers absents.
+  #
+  #    Le job `release` de desktop-build.yml est désormais SEUL propriétaire
+  #    de la release : il construit aussi les wheels, crée la release en
+  #    draft, y attache tous les fichiers, puis la publie. N'ajoute pas de
+  #    job de release ici sans supprimer celui-là.
   # -------------------------------------------------------------
-  release:
-    needs: [build_wheel, docker]
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    
-    permissions:
-      contents: write # Nécessaire pour créer la release
-
-    steps:
-      - uses: actions/checkout@v4
-      
-      # Récupère les artefacts construits par le job build_wheel
-      - name: Download Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-dist
-          path: dist
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          # Les notes de release sont écrites par le job `release` de
-          # desktop-build.yml, qui tourne sur le même tag. On ne fournit donc
-          # ni body ni generate_release_notes ici : ce job se contente
-          # d'attacher les wheels, sans écraser le corps de la release.
-          files: |
-            dist/*.whl
-            dist/*.tar.gz
-          draft: false
-          prerelease: false

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -122,10 +122,25 @@ jobs:
       contents: write
 
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
           pattern: anonyfiles-*
+
+      # Les wheels étaient publiées par ci.yml, qui attaquait la même release
+      # et gagnait la course. On les construit ici pour que ce job reste le
+      # seul à écrire sur la release.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build Python package
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+          python -m build
 
       - name: Collect and rename release assets
         shell: bash
@@ -154,6 +169,8 @@ jobs:
             echo "::error::Aucun installeur produit par le job desktop, rien à publier."
             exit 1
           fi
+
+          cp dist/*.whl dist/*.tar.gz release/
 
           (cd release && sha256sum * > SHA256SUMS.txt)
           ls -lh release
@@ -199,9 +216,21 @@ jobs:
           Les empreintes SHA-256 de tous les fichiers sont dans `SHA256SUMS.txt`.
           EOF
 
-      - uses: softprops/action-gh-release@v2
+      # Les releases immuables verrouillent les assets à la publication : il
+      # faut donc TOUT attacher pendant que la release est encore un draft,
+      # puis la publier dans un second temps. Inverser ces deux étapes fait
+      # échouer l'upload avec « Cannot upload asset to an immutable release ».
+      - name: Create draft release with all assets
+        uses: softprops/action-gh-release@v2
         with:
           files: release/*
           body_path: RELEASE_NOTES.md
           generate_release_notes: true
           fail_on_unmatched_files: true
+          draft: true
+          prerelease: false
+
+      - name: Publish the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "$GITHUB_REF_NAME" --draft=false --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
La release [v1.6.1](https://github.com/simongrossi/anonyfiles/releases/tag/v1.6.1) ne contient que les wheels Python : **aucun `.dmg`, `.msi` ni `.AppImage`**, alors que ses notes annoncent un tableau des trois plateformes. Les trois builds étaient pourtant verts.

## Cause

`ci.yml` et `desktop-build.yml` se déclenchent tous deux sur les tags `v*` et appelaient `action-gh-release` sur la **même** release. Cette course était déjà connue — le commit d'avril `fix(ci): éviter que ci.yml écrase les notes de la Release` la traitait déjà — mais elle était alors bénigne : le perdant écrasait juste le corps de la release.

L'activation des **releases immuables** l'a rendue fatale. La publication verrouille la release, et tout upload ultérieur est rejeté :

```
##[error]Cannot upload asset SHA256SUMS.txt to an immutable release.
GitHub only allows asset uploads before a release is published,
so upload assets to a draft release before you publish it.
```

Chronologie du run [32416730973](https://github.com/simongrossi/anonyfiles/actions/runs/32416730973) :

| Heure | Événement |
|---|---|
| 20:55 | tag `v1.6.1` poussé, les deux workflows démarrent |
| 21:07:28 | `ci.yml` crée **et publie** la release avec les wheels → verrouillage |
| 21:10:47 | `desktop-build.yml` tente d'attacher les 6 binaires → rejeté |

`ci.yml` est plus rapide (~12 min contre ~15 : pas de compilation Rust), il gagnait donc systématiquement.

## Corrections

**1. Un seul propriétaire de la release.** Le job `release` de `ci.yml` est supprimé, remplacé par un commentaire expliquant pourquoi il ne faut pas le réintroduire. Le job de `desktop-build.yml` construit désormais aussi les wheels (`python -m build`, ~20 s) et les verse dans `release/` — cela supprime tout couplage entre workflows, plutôt que d'ajouter un téléchargement d'artifact inter-run qui aurait été plus fragile.

**2. Draft puis publication.** Les assets sont attachés pendant que la release est encore un draft, puis `gh release edit --draft=false` la publie. C'est exactement la séquence que réclame le message d'erreur de GitHub.

Le job `build_wheel` de `ci.yml` est **conservé** : il valide le packaging sur chaque PR, indépendamment des releases.

L'immutabilité est préservée — c'est une protection chaîne d'approvisionnement, la désactiver aurait été un recul.

## Vérification

Les deux fichiers parsent (`yaml.safe_load`), `ci.yml` n'expose plus que `test`/`gui`/`build_wheel`/`docker`, et le job `release` de `desktop-build.yml` enchaîne bien checkout → download-artifact → build wheel → collect → draft → publish. Le job a déjà `permissions: contents: write`, requis par `gh release edit`.

Cette PR ne peut pas être testée à fond avant le prochain tag : le chemin `release` ne s'exécute que sur `refs/tags/v*`. C'est `v1.6.2` qui le validera réellement.

## Suite

`v1.6.1` reste publiée mais incomplète. Les binaires existent en artifacts du run ci-dessus (valides jusqu'au 18 novembre) si besoin immédiat. Une fois cette PR mergée, un tag `v1.6.2` produira une release complète.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZ4rb9J6Ceg8UyHwtnQpiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZ4rb9J6Ceg8UyHwtnQpiF)_